### PR TITLE
chore: upgrade calcit to 0.13.19

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -33,7 +33,6 @@ jobs:
         cr calcit.cirru edit format
         git diff --exit-code -- calcit.cirru
         cr calcit.cirru --check-only
-        cr calcit.cirru --entry server --check-only
 
     - name: Build browser client
       run: yarn compile-page && yarn release-page
@@ -42,7 +41,7 @@ jobs:
       name: Copy server scripts
 
     - name: Check deploy key availability
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: |
         if [ -z "$DEPLOY_KEY" ]; then
           echo "ERROR: DEPLOY_KEY (rsync_private_key) is empty or not available."
@@ -61,7 +60,7 @@ jobs:
         DEPLOY_KEY: ${{secrets.rsync_private_key}}
 
     - name: Upload web assets
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       id: deploy
       uses: Pendect/action-rsyncer@v2.0.0
       env:
@@ -74,11 +73,11 @@ jobs:
         dest: 'rsync-user@tiye.me:/web-assets/repo/${{ github.repository }}'
 
     - name: Display status from deploy
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: echo "${{ steps.deploy.outputs.status }}"
 
     - name: Upload server script
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       id: deploy-server
       uses: Pendect/action-rsyncer@v2.0.0
       env:
@@ -91,5 +90,5 @@ jobs:
         dest: 'rsync-user@tiye.me:/servers/timegrass/'
 
     - name: Display status from deploy
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: echo "${{ steps.deploy-server.outputs.status }}"

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - uses: actions/setup-node@v6
       with:
@@ -33,7 +33,6 @@ jobs:
         cr calcit.cirru edit format
         git diff --exit-code -- calcit.cirru
         cr calcit.cirru --check-only
-        cr calcit.cirru --entry server --check-only
 
     - name: Build browser client
       run: yarn compile-page && yarn release-page
@@ -42,7 +41,7 @@ jobs:
       name: Copy server scripts
 
     - name: Check deploy key availability
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: |
         if [ -z "$DEPLOY_KEY" ]; then
           echo "ERROR: DEPLOY_KEY (rsync_private_key) is empty or not available."
@@ -61,7 +60,7 @@ jobs:
         DEPLOY_KEY: ${{secrets.rsync_private_key}}
 
     - name: Upload web assets
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       id: deploy
       uses: Pendect/action-rsyncer@v2.0.0
       env:
@@ -74,11 +73,11 @@ jobs:
         dest: 'rsync-user@tiye.me:/web-assets/repo/${{ github.repository }}'
 
     - name: Display status from deploy
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: echo "${{ steps.deploy.outputs.status }}"
 
     - name: Upload server script
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       id: deploy-server
       uses: Pendect/action-rsyncer@v2.0.0
       env:
@@ -91,5 +90,5 @@ jobs:
         dest: 'rsync-user@tiye.me:/servers/timegrass/'
 
     - name: Display status from deploy
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: echo "${{ steps.deploy-server.outputs.status }}"

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - uses: actions/setup-node@v6
       with:
@@ -33,6 +33,7 @@ jobs:
         cr calcit.cirru edit format
         git diff --exit-code -- calcit.cirru
         cr calcit.cirru --check-only
+        cr calcit.cirru --entry server --check-only
 
     - name: Build browser client
       run: yarn compile-page && yarn release-page
@@ -41,7 +42,7 @@ jobs:
       name: Copy server scripts
 
     - name: Check deploy key availability
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: github.event_name == 'push'
       run: |
         if [ -z "$DEPLOY_KEY" ]; then
           echo "ERROR: DEPLOY_KEY (rsync_private_key) is empty or not available."
@@ -60,7 +61,7 @@ jobs:
         DEPLOY_KEY: ${{secrets.rsync_private_key}}
 
     - name: Upload web assets
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: github.event_name == 'push'
       id: deploy
       uses: Pendect/action-rsyncer@v2.0.0
       env:
@@ -73,11 +74,11 @@ jobs:
         dest: 'rsync-user@tiye.me:/web-assets/repo/${{ github.repository }}'
 
     - name: Display status from deploy
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: github.event_name == 'push'
       run: echo "${{ steps.deploy.outputs.status }}"
 
     - name: Upload server script
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: github.event_name == 'push'
       id: deploy-server
       uses: Pendect/action-rsyncer@v2.0.0
       env:
@@ -90,5 +91,5 @@ jobs:
         dest: 'rsync-user@tiye.me:/servers/timegrass/'
 
     - name: Display status from deploy
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: github.event_name == 'push'
       run: echo "${{ steps.deploy-server.outputs.status }}"

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,46 +1,38 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |app)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |app) (:version |0.1.0)
   :entries $ {}
     :default $ {} (:description "||Browser client bundle") (:init-fn 'app.client/main!) (:mode :js) (:reload-fn 'app.client/reload!)
-      :feature-policy $ {}
-      :modules $ [] |recollect/ |respo-ui.calcit/ |ws-edn.calcit/ |cumulo-util.calcit/ |respo-message.calcit/ |cumulo-reel.calcit/ |respo-feather.calcit/ |alerts.calcit/ |respo-markdown.calcit/ |respo.calcit/ |js-ffi/
+      :modules $ [] |lilac/ |recollect/ |memof/ |respo-ui.calcit/ |ws-edn.calcit/ |cumulo-util.calcit/ |respo-message.calcit/ |cumulo-reel.calcit/ |respo-feather.calcit/ |alerts.calcit/ |respo-markdown.calcit/ |respo.calcit/ |js-ffi/
       :type-slots $ {}
     :server $ {} (:description "||Realtime server") (:init-fn 'app.server/main!) (:mode :native) (:reload-fn 'app.server/reload!)
-      :feature-policy $ {}
-      :modules $ [] |recollect/ |cumulo-util.calcit/ |cumulo-reel.calcit/ |calcit.std/ |calcit-wss/
+      :modules $ [] |lilac/ |recollect/ |memof/ |cumulo-util.calcit/ |cumulo-reel.calcit/ |calcit.std/ |calcit-wss/
       :type-slots $ {}
   :files $ {}
-    |app.client $ %{} 'FileEntry
+    |app.client $ %{} :FileEntry
       :defs $ {}
-        |*states $ %{} 'CodeEntry (:doc |)
+        |*states $ %{} :CodeEntry (:doc |)
           :code $ quote
             defatom *states $ {}
               :states $ {}
                 :cursor $ []
           :examples $ []
           :schema $ :: 'Dynamic
-        |*store $ %{} 'CodeEntry (:doc |)
+        |*store $ %{} :CodeEntry (:doc |)
           :code $ quote
             defatom *store $ :: :initial
           :examples $ []
           :schema $ :: 'Dynamic
-        |connect! $ %{} 'CodeEntry (:doc |)
+        |connect! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn connect! () $ let
-                url-obj $ unsafe-coerce (url-parse js/location.href true) 'JsObject
-                query $ unsafe-coerce (.-query url-obj) 'JsObject
-                host $ unsafe-coerce
-                  if
-                    js-present? $ .-host query
-                    .-host query
-                    unsafe-coerce js/location.hostname 'String
-                  , 'String
-                port $ unsafe-coerce
-                  if
-                    js-present? $ .-port query
-                    .-port query
-                    :port config/site
-                  , 'String
+                location $ unsafe-coerce js/location JsObject
+                url-obj $ unsafe-coerce (url-parse (.-href location) true) JsObject
+                query $ unsafe-coerce (.-query url-obj) JsObject
+                raw-host $ .-host query
+                raw-port $ .-port query
+                raw-hostname $ .-hostname location
+                host $ if (js-present? raw-host) (unsafe-coerce raw-host String) raw-hostname
+                port $ if (js-present? raw-port) (unsafe-coerce raw-port String) (:port config/site)
               ws-connect!
                 if config/dev? (str |ws:// host |: port) |wss://timegrass.topix.im/ws
                 {}
@@ -51,7 +43,7 @@
                   :on-data on-server-data
           :examples $ []
           :schema $ :: 'Dynamic
-        |dispatch! $ %{} 'CodeEntry (:doc |)
+        |dispatch! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn dispatch! (op)
               when
@@ -64,7 +56,7 @@
                 _ $ ws-send! op
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} 'CodeEntry (:doc |)
+        |main! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn main! () (.!extend dayjs week-of-year)
               println "|Running mode:" $ if config/dev? |dev |release
@@ -86,12 +78,12 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |mount-target $ %{} 'CodeEntry (:doc |)
+        |mount-target $ %{} :CodeEntry (:doc |)
           :code $ quote
             def mount-target $ js/document.querySelector |.app
           :examples $ []
           :schema $ :: 'Dynamic
-        |on-server-data $ %{} 'CodeEntry (:doc |)
+        |on-server-data $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn on-server-data (data)
               tag-match data
@@ -102,7 +94,7 @@
                 (:effect/pong) :ok
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} 'CodeEntry (:doc |)
+        |reload! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ if
               or $ some? client-errors
@@ -113,25 +105,25 @@
                 println "|Code updated."
           :examples $ []
           :schema $ :: 'Dynamic
-        |render-app! $ %{} 'CodeEntry (:doc |)
+        |render-app! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn render-app! () $ render! mount-target
-              comp-container (&map:get @*states :states) @*store
+              comp-container (:states @*states) @*store
               , dispatch!
           :examples $ []
           :schema $ :: 'Dynamic
-        |simulate-login! $ %{} 'CodeEntry (:doc |)
+        |simulate-login! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn simulate-login! () $ let
                 raw $ js/localStorage.getItem (:storage-key config/site)
               if (js-present? raw)
                 do (println "|Found storage.")
                   dispatch! $ :: :user/log-in
-                    parse-cirru-edn $ unsafe-coerce raw 'String
+                    parse-cirru-edn $ unsafe-coerce raw String
                 do $ println "|Found no storage."
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns app.client $ :require
             respo.core :refer $ render! clear-cache! realize-ssr!
@@ -147,43 +139,45 @@
             |./calcit.build-errors :default client-errors
             |dayjs :default dayjs
             |dayjs/plugin/weekOfYear :default week-of-year
-    |app.comp.container $ %{} 'FileEntry
+    |app.comp.container $ %{} :FileEntry
       :defs $ {}
-        |comp-container $ %{} 'CodeEntry (:doc |)
+        |comp-container $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn comp-container (states store)
               case-default store
                 let
-                    state $ &map:get states :data
-                    session $ &map:get store :session
-                    router $ &map:get store :router
-                    router-data $ &map:get router :data
+                    state $ :data states
+                    session $ :session store
+                    router $ :router store
+                    router-data $ :data router
                   div
                     {} $ :class-name css-container
-                    comp-navigation (&map:get store :logged-in?) (&map:get store :count) (&map:get router :name)
-                    if (&map:get store :logged-in?)
-                      case-default (&map:get router :name)
+                    comp-navigation (:logged-in? store) (:count store) (:name router)
+                    if (:logged-in? store)
+                      case-default (:name router)
                         <> $ str "|404 page:" router
-                        :home $ comp-overview (>> states :overview) (&map:get store :today)
+                        :home $ comp-overview (>> states :overview) (:today store)
                           get-in router $ [] :data :tasks
                         :history $ comp-history (>> states :history)
                           get-in router $ [] :data :week
                           get-in router $ [] :data :tasks
-                        :notes $ comp-notes-page (>> states :notes) (&map:get router :data)
+                        :notes $ comp-notes-page (>> states :notes) (:data router)
                           get-in session $ [] :router :data
-                        :profile $ comp-profile (&map:get store :user) (&map:get router :data)
+                        :profile $ comp-profile (:user store) (:data router)
                       comp-login $ >> states :login
-                    comp-status-color $ &map:get store :color
+                    comp-status-color $ :color store
                     when dev? $ comp-inspect |Store store
                       {} (:bottom 0) (:left 0) (:z-index 9999)
-                    comp-messages (&map:get session :messages) ({})
+                    comp-messages
+                      get-in store $ [] :session :messages
+                      {}
                       fn (info d!) (d! :session/remove-message info)
-                    when dev? $ comp-reel (&map:get store :reel-length) ({})
+                    when dev? $ comp-reel (:reel-length store) ({})
                 (:: :initial) (comp-offline :initial)
                 (:: :offline) (comp-offline :offline)
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-offline $ %{} 'CodeEntry (:doc |)
+        |comp-offline $ %{} :CodeEntry (:doc |)
           :code $ quote
             defcomp comp-offline (state)
               div
@@ -205,39 +199,39 @@
                     {} (:font-family ui/font-fancy) (:font-weight 100) (:font-size 24)
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-status-color $ %{} 'CodeEntry (:doc |)
+        |comp-status-color $ %{} :CodeEntry (:doc |)
           :code $ quote
             defcomp comp-status-color (color)
               div $ {} (:class-name css-status-color)
                 :style $ {} (:background-color color)
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-container $ %{} 'CodeEntry (:doc |)
+        |css-container $ %{} :CodeEntry (:doc |)
           :code $ quote
             defstyle css-container $ {}
               |$0 $ merge ui/global ui/fullscreen ui/column
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-offline $ %{} 'CodeEntry (:doc |)
+        |css-offline $ %{} :CodeEntry (:doc |)
           :code $ quote
             defstyle css-offline $ {}
               |$0 $ merge ui/global ui/fullscreen ui/column-dispersive
                 {} $ :background-color (:theme config/site)
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-status-color $ %{} 'CodeEntry (:doc |)
+        |css-status-color $ %{} :CodeEntry (:doc |)
           :code $ quote
             defstyle css-status-color $ {}
               |$0 $ {} (:width 16) (:height 16) (:position :absolute) (:bottom 16) (:right 8) (:border-radius |8px) (:opacity 0.8) (:transition-duration |200ms) (:opacity 0.5)
               |$0:hover $ {} (:opacity 0.7)
           :examples $ []
           :schema $ :: 'Dynamic
-        |style-body $ %{} 'CodeEntry (:doc |)
+        |style-body $ %{} :CodeEntry (:doc |)
           :code $ quote
             def style-body $ {} (:padding "|8px 16px")
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns app.comp.container $ :require
             hsl.core :refer $ hsl
@@ -258,29 +252,26 @@
             app.config :as config
             app.comp.history :refer $ comp-history
             app.comp.notes-page :refer $ comp-notes-page
-    |app.comp.history $ %{} 'FileEntry
+    |app.comp.history $ %{} :FileEntry
       :defs $ {}
-        |comp-done-task $ %{} 'CodeEntry (:doc |)
+        |comp-done-task $ %{} :CodeEntry (:doc |)
           :code $ quote
             defcomp comp-done-task (states task)
               let
-                  cursor $ &map:get states :cursor
-                  state $ or (&map:get states :data)
+                  cursor $ :cursor states
+                  state $ or (:data states)
                     {} $ :show-menu? false
-                  finished-day $ unsafe-coerce
-                    dayjs $ &map:get task :finished-time
-                    , 'JsObject
                 div
                   {} (:class-name css-done-task)
                     :style $ merge
                       {} $ :padding "|4px 8px"
-                      if (&map:get state :show-menu?)
+                      if (:show-menu? state)
                         {} $ :background-color (hsl 0 0 94)
                         {}
                     :on-click $ fn (e d!)
                       d! cursor $ assoc state :show-menu? true
                   <>
-                    unsafe-coerce (.!format finished-day |HH:mm) 'String
+                    -> (:finished-time task) dayjs $ .!format |HH:mm
                     {} (:min-width 32)
                       :color $ hsl 0 0 80
                       :font-size 12
@@ -289,27 +280,27 @@
                   span
                     {} $ :style
                       merge ui/flex $ {} (:line-height |24px)
-                    <> $ &map:get task :text
+                    <> $ :text task
                   comp-modal-menu
                     {} (:title |Operations)
                       :style $ {} (:width 320)
                       :items $ [] (:: :item :put-back "|Put back")
-                    &map:get state :show-menu?
+                    :show-menu? state
                     fn (d!)
                       d! cursor $ assoc state :show-menu? false
                     fn (item d!)
                       d! cursor $ assoc state :show-menu? false
                       when
-                        = :put-back $ option:unwrap-or (nth item 1) nil
-                        d! :task/put-back $ &map:get task :id
+                        = :put-back $ nth item 1
+                        d! :task/put-back $ :id task
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-history $ %{} 'CodeEntry (:doc |)
+        |comp-history $ %{} :CodeEntry (:doc |)
           :code $ quote
             defcomp comp-history (states data finished-tasks)
               let
-                  year $ &map:get data :year
-                  week $ &map:get data :week
+                  year $ :year data
+                  week $ :week data
                 div
                   {} (:class-name css/flex)
                     :style $ {} (:padding "|16px 16px") (:overflow :auto)
@@ -334,14 +325,10 @@
                                   change-year? $ <= week 1
                                   y $ if change-year? (dec year) year
                                   w $ if change-year? 53 (dec week)
-                                  base-day $ unsafe-coerce (dayjs) 'JsObject
-                                  year-day $ unsafe-coerce (.!year base-day y) 'JsObject
-                                  d $ unsafe-coerce (.!week year-day w) 'JsObject
-                                  start-day $ unsafe-coerce (.!startOf d |week) 'JsObject
-                                  end-day $ unsafe-coerce (.!endOf d |week) 'JsObject
+                                  d $ -> (dayjs) (.!year y) (.!week w)
                                 {} (:year y) (:week w)
-                                  :start $ unsafe-coerce (.!format start-day |week) 'String
-                                  :end $ unsafe-coerce (.!format end-day |week) 'String
+                                  :start $ .!format (.!startOf d |week)
+                                  :end $ .!format (.!endOf d |week)
                         =< 8 nil
                         comp-icon :arrow-right
                           {} (:font-size 16)
@@ -353,14 +340,10 @@
                                   change-year? $ >= week 53
                                   y $ if change-year? (inc year) year
                                   w $ if change-year? 1 (inc week)
-                                  base-day $ unsafe-coerce (dayjs) 'JsObject
-                                  year-day $ unsafe-coerce (.!year base-day y) 'JsObject
-                                  d $ unsafe-coerce (.!week year-day w) 'JsObject
-                                  start-day $ unsafe-coerce (.!startOf d |week) 'JsObject
-                                  end-day $ unsafe-coerce (.!endOf d |week) 'JsObject
+                                  d $ -> (dayjs) (.!year y) (.!week w)
                                 {} (:year y) (:week w)
-                                  :start $ unsafe-coerce (.!format start-day |week) 'String
-                                  :end $ unsafe-coerce (.!format end-day |week) 'String
+                                  :start $ .!format (.!startOf d |week)
+                                  :end $ .!format (.!endOf d |week)
                     if (empty? finished-tasks)
                       div
                         {} (:class-name css/center)
@@ -370,45 +353,39 @@
                       let
                           grouped-tasks $ -> finished-tasks (.to-list) (.map last)
                             group-by $ fn (task)
-                              unsafe-coerce
-                                .!format
-                                  unsafe-coerce
-                                    dayjs $ &map:get task :finished-time
-                                    , 'JsObject
-                                  , |YYYY-MM-DD
-                                , 'String
+                              .!format
+                                dayjs $ :finished-time task
+                                , |YYYY-MM-DD
                         list-> ({})
                           -> grouped-tasks (.to-list)
                             .sort $ fn (x y)
-                              &compare
-                                option:unwrap-or (first y) |
-                                option:unwrap-or (first x) |
+                              &compare (first y) (first x)
                             .map-pair $ fn (date-string task-list)
                               [] date-string $ div
                                 {} (:class-name css/column)
                                   :style $ {} (:margin-top 16)
                                 let
-                                    the-day $ unsafe-coerce (dayjs date-string) 'JsObject
+                                    the-day $ dayjs date-string
                                   div
                                     {} $ :class-name css/row-parted
                                     span
                                       {} $ :class-name css/font-fancy
-                                      <> $ unsafe-coerce (.!format the-day |ddd) 'String
+                                      <> $ .!format the-day |ddd
                                       =< 12 nil
-                                      <> $ unsafe-coerce (.!format the-day |MM-DD) 'String
+                                      <> $ .!format the-day |MM-DD
                                 =< nil 4
                                 list-> ({})
                                   -> task-list
                                     .sort-by $ fn (task)
-                                      negate $ &map:get task :finished-time
+                                      negate $ :finished-time task
                                     .map $ fn (task)
-                                      [] (&map:get task :id)
+                                      [] (:id task)
                                         comp-done-task
-                                          >> states $ &map:get task :id
+                                          >> states $ :id task
                                           , task
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-done-task $ %{} 'CodeEntry (:doc |)
+        |css-done-task $ %{} :CodeEntry (:doc |)
           :code $ quote
             defstyle css-done-task $ {}
               |$0 $ {} (:transition-duration |200ms)
@@ -416,7 +393,7 @@
                 :background-color $ hsl 0 0 80 0.2
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns app.comp.history $ :require
             respo-ui.core :refer $ hsl
@@ -429,14 +406,14 @@
             respo-alerts.core :refer $ comp-modal-menu
             |dayjs :default dayjs
             feather.core :refer $ comp-icon
-    |app.comp.login $ %{} 'FileEntry
+    |app.comp.login $ %{} :FileEntry
       :defs $ {}
-        |comp-login $ %{} 'CodeEntry (:doc |)
+        |comp-login $ %{} :CodeEntry (:doc |)
           :code $ quote
             defcomp comp-login (states)
               let
-                  cursor $ &map:get states :cursor
-                  state $ or (&map:get states :data) initial-state
+                  cursor $ :cursor states
+                  state $ or (:data states) initial-state
                 div
                   {} $ :style (merge ui/flex ui/center)
                   div ({})
@@ -444,38 +421,38 @@
                       {} $ :style ({})
                       div ({})
                         input $ {} (:placeholder |Username)
-                          :value $ &map:get state :username
+                          :value $ :username state
                           :style ui/input
                           :on-input $ fn (e d!)
                             d! cursor $ assoc state :username
-                              str $ &map:get e :value
+                              str $ :value e
                       =< nil 8
                       div ({})
                         input $ {} (:placeholder |Password)
-                          :value $ &map:get state :password
+                          :value $ :password state
                           :style ui/input
                           :on-input $ fn (e d!)
                             d! cursor $ assoc state :password
-                              str $ &map:get e :value
+                              str $ :value e
                     =< nil 8
                     div
                       {} $ :style
                         {} $ :text-align :right
                       span $ {} (:inner-text "|Sign up")
                         :style $ merge style/link
-                        :on-click $ on-submit (&map:get state :username) (&map:get state :password) true
+                        :on-click $ on-submit (:username state) (:password state) true
                       =< 8 nil
                       span $ {} (:inner-text "|Log in")
                         :style $ merge style/link
-                        :on-click $ on-submit (&map:get state :username) (&map:get state :password) false
+                        :on-click $ on-submit (:username state) (:password state) false
           :examples $ []
           :schema $ :: 'Dynamic
-        |initial-state $ %{} 'CodeEntry (:doc |)
+        |initial-state $ %{} :CodeEntry (:doc |)
           :code $ quote
             def initial-state $ {} (:username |) (:password |)
           :examples $ []
           :schema $ :: 'Dynamic
-        |on-submit $ %{} 'CodeEntry (:doc |)
+        |on-submit $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn on-submit (username password signup?)
               fn (e dispatch!)
@@ -484,7 +461,7 @@
                   format-cirru-edn $ [] username password
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns app.comp.login $ :require
             [] respo.core :refer $ [] defcomp <> div input button span
@@ -494,9 +471,9 @@
             [] app.schema :as schema
             [] app.style :as style
             [] app.config :as config
-    |app.comp.navigation $ %{} 'FileEntry
+    |app.comp.navigation $ %{} :FileEntry
       :defs $ {}
-        |comp-navigation $ %{} 'CodeEntry (:doc |)
+        |comp-navigation $ %{} :CodeEntry (:doc |)
           :code $ quote
             defcomp comp-navigation (logged-in? count-members page)
               div
@@ -513,22 +490,20 @@
                     render-entry |Finished
                       fn () $ {} (:name :history)
                         :data $ let
-                            now $ unsafe-coerce (dayjs) 'JsObject
+                            now $ dayjs
                             month $ .!month now
-                            week-date $ unsafe-coerce now 'JsObject
-                            start-day $ unsafe-coerce (.!startOf week-date |week) 'JsObject
-                            end-day $ unsafe-coerce (.!endOf week-date |week) 'JsObject
+                            week-date now
                           {}
                             :year $ .!year now
                             :week $ .!week week-date
-                            :start $ unsafe-coerce (.!format start-day |week) 'String
-                            :end $ unsafe-coerce (.!format end-day |week) 'String
+                            :start $ .!format (.!startOf week-date |week)
+                            :end $ .!format (.!endOf week-date |week)
                       = page :history
                     =< 16 nil
                     render-entry |Notes
                       fn () $ {} (:name :notes)
                         :data $ let
-                            now $ unsafe-coerce (dayjs) 'JsObject
+                            now $ dayjs
                           {}
                             :year $ .!year now
                             :month $ .!month now
@@ -544,14 +519,14 @@
                     <> count-members
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-entry $ %{} 'CodeEntry (:doc |)
+        |css-entry $ %{} :CodeEntry (:doc |)
           :code $ quote
             defstyle css-entry $ {}
               |$0 $ {} (:opacity 0.6) (:user-select :none) (:transition-duration |200ms)
               |$0:hover $ {} (:opacity 0.8)
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-navbar $ %{} 'CodeEntry (:doc |)
+        |css-navbar $ %{} :CodeEntry (:doc |)
           :code $ quote
             defstyle css-navbar $ {}
               |$0 $ merge ui/row-center
@@ -562,7 +537,7 @@
                   :color :white
           :examples $ []
           :schema $ :: 'Dynamic
-        |render-entry $ %{} 'CodeEntry (:doc |)
+        |render-entry $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn render-entry (title get-route highlighted?)
               div
@@ -576,7 +551,7 @@
                 <> title nil
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns app.comp.navigation $ :require
             respo-ui.core :refer $ hsl
@@ -588,20 +563,17 @@
             app.config :as config
             respo-alerts.core :refer $ comp-prompt
             |dayjs :default dayjs
-    |app.comp.notes-page $ %{} 'FileEntry
+    |app.comp.notes-page $ %{} :FileEntry
       :defs $ {}
-        |comp-note $ %{} 'CodeEntry (:doc |)
+        |comp-note $ %{} :CodeEntry (:doc |)
           :code $ quote
             defcomp comp-note (states note)
               let
                   edit-plugin $ use-prompt (>> states :edit)
                     {} (:text "|Update note:") (:multiline? true)
-                      :initial $ &map:get note :text
+                      :initial $ :text note
                   remove-plugin $ use-confirm (>> states :remove)
                     {} $ :text "|Sure to delete note?"
-                  note-day $ unsafe-coerce
-                    dayjs $ &map:get note :time
-                    , 'JsObject
                 div
                   {}
                     :class-name $ str-spaced css/column css-note
@@ -611,7 +583,7 @@
                   div
                     {} $ :class-name css/row-parted
                     <>
-                      unsafe-coerce (.!format note-day |HH:mm) 'String
+                      -> (:time note) dayjs $ .!format |HH:mm
                       {} (:font-family ui/font-fancy)
                         :color $ hsl 0 0 70
                         :font-size 12
@@ -623,25 +595,25 @@
                         fn (e d!)
                           .show edit-plugin d! $ fn (result)
                             d! :note/edit $ {}
-                              :id $ &map:get note :id
+                              :id $ :id note
                               :text result
                       =< 8 nil
                       comp-icon :delete
                         &{} :font-size 16 :cursor :pointer :color $ hsl 10 80 60
                         fn (e d!)
                           .show remove-plugin d! $ fn ()
-                            d! :note/remove $ &map:get note :id
-                  <> $ &map:get note :text
+                            d! :note/remove $ :id note
+                  <> $ :text note
                   .render edit-plugin
                   .render remove-plugin
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-notes-page $ %{} 'CodeEntry (:doc |)
+        |comp-notes-page $ %{} :CodeEntry (:doc |)
           :code $ quote
             defcomp comp-notes-page (states notes info)
               let
-                  year $ &map:get info :year
-                  month $ &map:get info :month
+                  year $ :year info
+                  month $ :month info
                   add-plugin $ use-prompt (>> states :add)
                     {} (:text "|Add note about today's work:") (:multiline? true)
                 div
@@ -705,19 +677,12 @@
                       let
                           grouped-notes $ -> notes (.to-list)
                             .group-by $ fn (pair)
-                              let
-                                  pair-value $ unsafe-coerce (nth pair 1) 'Dynamic
-                                  note-time $ &map:get pair-value :time
-                                unsafe-coerce
-                                  .!format
-                                    unsafe-coerce (dayjs note-time) 'JsObject
-                                    , |MM-DD
-                                  , 'String
+                              ->
+                                :time $ last pair
+                                , dayjs $ .!format |MM-DD
                             .to-list
                             .sort $ fn (x y)
-                              &compare
-                                option:unwrap-or (first y) |
-                                option:unwrap-or (first x) |
+                              &compare (first y) (first x)
                         list-> ({})
                           -> grouped-notes (.to-list)
                             .map-pair $ fn (date notes-in-day)
@@ -727,29 +692,21 @@
                                 div
                                   {} (:class-name css/font-fancy)
                                     :style $ {} (:font-size 14) (:font-weight 500)
-                                  <> $ unsafe-coerce
-                                    .!format
-                                      unsafe-coerce
-                                        dayjs $ str year |- date
-                                        , 'JsObject
-                                      , |ddd
-                                    , 'String
+                                  <> $ -> (str year |- date) dayjs (.!format |ddd)
                                   =< 12 nil
                                   <> $ str date
                                 list->
                                   {} $ :class-name css/column
                                   -> notes-in-day
                                     .sort-by $ fn (pair)
-                                      let
-                                          note-value $ unsafe-coerce (nth pair 1) 'Dynamic
-                                        negate $ &map:get note-value :time
+                                      negate $ :time (last pair)
                                     .map-pair $ fn (k note)
                                       [] k $ comp-note (>> states k) note
                     =< nil 160
                   .render add-plugin
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-note $ %{} 'CodeEntry (:doc |)
+        |css-note $ %{} :CodeEntry (:doc |)
           :code $ quote
             defstyle css-note $ {}
               |$0 $ {} (:transition-duration |200ms)
@@ -757,7 +714,7 @@
                 :background-color $ hsl 0 0 80 0.2
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns app.comp.notes-page $ :require
             respo-ui.core :refer $ hsl
@@ -771,16 +728,9 @@
             respo-alerts.core :refer $ use-prompt use-confirm
             feather.core :refer $ comp-i comp-icon
             |dayjs :default dayjs
-    |app.comp.overview $ %{} 'FileEntry
+    |app.comp.overview $ %{} :FileEntry
       :defs $ {}
-        |comp-global-keydown $ %{} 'CodeEntry (:doc |)
-          :code $ quote
-            defcomp comp-global-keydown (options on-event)
-              span $ {}
-                :on-keydown $ fn (e d!) (on-event e d!)
-          :examples $ []
-          :schema $ :: 'Dynamic
-        |comp-no-tasks $ %{} 'CodeEntry (:doc |)
+        |comp-no-tasks $ %{} :CodeEntry (:doc |)
           :code $ quote
             defcomp comp-no-tasks () $ div
               {}
@@ -790,22 +740,21 @@
               <> "|No tasks"
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-overview $ %{} 'CodeEntry (:doc |)
+        |comp-overview $ %{} :CodeEntry (:doc |)
           :code $ quote
             defcomp comp-overview (states today tasks)
               let
                   working-tasks $ -> tasks (.to-map)
                     filter $ fn (pair)
-                      not $ &map:get (last pair) :pending?
+                      not $ :pending? (last pair)
                   pending-tasks $ -> tasks (.to-map)
                     filter $ fn (pair)
-                      &map:get (last pair) :pending?
+                      :pending? $ last pair
                   create-plugin $ use-prompt (>> states :create)
                     {} $ :text "|Create new task:"
-                  cursor $ &map:get states :cursor
-                  state $ or (&map:get states :data)
+                  cursor $ :cursor states
+                  state $ or (:data states)
                     {} $ :show-later? false
-                  today-day $ unsafe-coerce (dayjs today) 'JsObject
                 div
                   {} (:class-name css/expand)
                     :style $ {} (:padding 16)
@@ -821,17 +770,19 @@
                       comp-global-keydown ({})
                         fn (e d!)
                           if
-                            and (&map:get e :meta?)
-                              = |i $ &map:get e :key
+                            and (:meta? e)
+                              = |i $ :key e
                             .show create-plugin d! $ fn (result) (d! :task/create-working result)
                       div
                         {}
                           :class-name $ str-spaced css/row-middle css/font-fancy
                           :style $ {}
                             :color $ hsl 0 0 60
-                        <> $ unsafe-coerce (.!format today-day |ddd) 'String
+                        <> $ .!format (dayjs today) |ddd
                         =< 8 nil
-                        <> $ str (.!week today-day) "|th week"
+                        <> $ str
+                          .!week $ dayjs today
+                          , "|th week"
                         =< 16 nil
                         <> today
                     if (empty? working-tasks) (comp-no-tasks)
@@ -840,26 +791,26 @@
                           .sort-by $ fn (pair)
                             let
                                 task $ last pair
-                              negate $ or (&map:get task :touched-time) (&map:get task :created-time)
+                              negate $ or (:touched-time task) (:created-time task)
                           .map-pair $ fn (k task)
                             [] k $ comp-task
-                              >> states $ &map:get task :id
+                              >> states $ :id task
                               , task :working
                     when
                       not $ empty? pending-tasks
                       div ({})
                         comp-title |Later nil $ fn (e d!)
                           d! cursor $ update state :show-later? not
-                        if (&map:get state :show-later?)
+                        if (:show-later? state)
                           list-> ({})
                             -> pending-tasks (.to-list)
                               .sort-by $ fn (pair)
                                 let
                                     task $ last pair
-                                  negate $ or (&map:get task :touched-time) (&map:get task :created-time)
+                                  negate $ or (:touched-time task) (:created-time task)
                               .map-pair $ fn (k task)
                                 [] k $ comp-task
-                                  >> states $ &map:get task :id
+                                  >> states $ :id task
                                   , task :pending
                           div
                             {}
@@ -872,16 +823,16 @@
                     .render create-plugin
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-task $ %{} 'CodeEntry (:doc |)
+        |comp-task $ %{} :CodeEntry (:doc |)
           :code $ quote
             defcomp comp-task (states task mode)
               let
-                  cursor $ &map:get states :cursor
-                  state $ or (&map:get states :data)
+                  cursor $ :cursor states
+                  state $ or (:data states)
                     {} $ :menu? false
                   update-plugin $ use-prompt (>> states :drafter)
                     {} (:text "|Task content:")
-                      :initial $ &map:get task :text
+                      :initial $ :text task
                       :placeholder |task...
                       :button-text |Edit
                   delete-plugin $ use-confirm (>> states :delete)
@@ -889,18 +840,18 @@
                 div
                   {} (:class-name css-task-base)
                     :style $ merge
-                      if (&map:get state :menu?)
+                      if (:menu? state)
                         {} $ :background-color (hsl 0 0 94)
                         {}
                     :on-click $ fn (e d!)
                       d! cursor $ assoc state :menu? true
                     :on $ {}
                       :dragend $ fn (e d!)
-                        d! :task/touch-working $ &map:get task :id
+                        d! :task/touch-working $ :id task
                     :draggable true
                   div
                     {} $ :style ui/flex
-                    <> (&map:get task :text) ({})
+                    <> (:text task) ({})
                   comp-modal-menu
                     {} (:title |Operations)
                       :style $ {} (:width 320)
@@ -910,7 +861,7 @@
                         :: :item :copy |Copy
                         :: :item :edit |Edit
                         :: :item :remove |Remove
-                    &map:get state :menu?
+                    :menu? state
                     fn (d!)
                       d! cursor $ assoc state :menu? false
                     fn (item d!)
@@ -920,30 +871,30 @@
                         js/console.log item
                         case-default result (d! cursor new-state)
                           :done $ do
-                            d! :task/finish-working $ &map:get task :id
+                            d! :task/finish-working $ :id task
                             d! cursor new-state
                           :edit $ do (d! cursor new-state)
                             .show update-plugin d! $ fn (text)
                               d! :task/update-working $ {}
-                                :id $ &map:get task :id
+                                :id $ :id task
                                 :text text
                           :copy $ do
-                            copy! $ &map:get task :text
+                            copy! $ :text task
                             d! cursor new-state
                           :remove $ do (d! cursor new-state)
                             .show delete-plugin d! $ fn ()
-                            d! :task/remove-working $ &map:get task :id
+                              d! :task/remove-working $ :id task
                           :pend $ do
-                            d! :task/pend $ &map:get task :id
+                            d! :task/pend $ :id task
                             d! cursor new-state
                           :touch $ do
-                            d! :task/touch-working $ &map:get task :id
+                            d! :task/touch-working $ :id task
                             d! cursor new-state
                   .render update-plugin
                   .render delete-plugin
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-title $ %{} 'CodeEntry (:doc |)
+        |comp-title $ %{} :CodeEntry (:doc |)
           :code $ quote
             defcomp comp-title (title child ? on-click)
               div
@@ -957,7 +908,7 @@
                 , child
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-task-base $ %{} 'CodeEntry (:doc |)
+        |css-task-base $ %{} :CodeEntry (:doc |)
           :code $ quote
             defstyle css-task-base $ {}
               |$0 $ {}
@@ -971,7 +922,7 @@
                 :background-color $ hsl 0 0 80 0.1
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-title $ %{} 'CodeEntry (:doc |)
+        |css-title $ %{} :CodeEntry (:doc |)
           :code $ quote
             defstyle css-title $ {}
               |$0 $ merge ui/row-middle
@@ -981,7 +932,7 @@
                   :font-weight 300
           :examples $ []
           :schema $ :: 'Dynamic
-        |effect-focus $ %{} 'CodeEntry (:doc |)
+        |effect-focus $ %{} :CodeEntry (:doc |)
           :code $ quote
             defeffect effect-focus () (action el *local)
               case action
@@ -989,7 +940,7 @@
                 do
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns app.comp.overview $ :require
             respo-ui.core :refer $ hsl
@@ -1005,9 +956,10 @@
             feather.core :refer $ comp-i comp-icon
             |dayjs :default dayjs
             |copy-text-to-clipboard :default copy!
-    |app.comp.profile $ %{} 'FileEntry
+            respo.comp.global-keydown :refer $ comp-global-keydown
+    |app.comp.profile $ %{} :FileEntry
       :defs $ {}
-        |comp-profile $ %{} 'CodeEntry (:doc |)
+        |comp-profile $ %{} :CodeEntry (:doc |)
           :code $ quote
             defcomp comp-profile (user members)
               div
@@ -1019,7 +971,7 @@
                   div
                     {} (:class-name css/font-fancy)
                       :style $ {} (:font-size 32) (:font-weight 100)
-                    <> $ str "|Hello! " (&map:get user :name)
+                    <> $ str "|Hello! " (:name user)
                   =< nil 16
                   div
                     {} $ :class-name css/row
@@ -1048,7 +1000,7 @@
                       <> "|Log out"
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-member-label $ %{} 'CodeEntry (:doc |)
+        |css-member-label $ %{} :CodeEntry (:doc |)
           :code $ quote
             defstyle css-member-label $ {}
               |$0 $ {} (:padding "|0 8px")
@@ -1057,7 +1009,7 @@
                 :margin "|0 4px"
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns app.comp.profile $ :require
             respo-ui.core :refer $ hsl
@@ -1068,29 +1020,28 @@
             respo.css :refer $ defstyle
             respo.comp.space :refer $ =<
             app.config :as config
-    |app.config $ %{} 'FileEntry
+    |app.config $ %{} :FileEntry
       :defs $ {}
-        |dev? $ %{} 'CodeEntry (:doc |)
+        |dev? $ %{} :CodeEntry (:doc |)
           :code $ quote
-            def dev? $ = |dev
-              option:unwrap-or (get-env |mode) |release
+            def dev? $ = |dev $ option:unwrap-or (get-env |mode) |release
           :examples $ []
           :schema $ :: 'Dynamic
-        |site $ %{} 'CodeEntry (:doc |)
+        |site $ %{} :CodeEntry (:doc |)
           :code $ quote
             def site $ {} (:port 11009) (:title |Timegrass) (:icon |http://cdn.tiye.me/logo/timegrass.png) (:dev-ui |http://localhost:8100/main.css) (:release-ui |http://cdn.tiye.me/favored-fonts/main.css) (:cdn-url |http://cdn.tiye.me/timegrass/) (:theme |#51C766) (:storage-key |timegrass) (:storage-file |storage.cirru)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote (ns app.config)
-    |app.schema $ %{} 'FileEntry
+    |app.schema $ %{} :FileEntry
       :defs $ {}
-        |complain $ %{} 'CodeEntry (:doc |)
+        |complain $ %{} :CodeEntry (:doc |)
           :code $ quote
             def complain $ {} (:id nil) (:text |) (:time nil)
           :examples $ []
           :schema $ :: 'Dynamic
-        |database $ %{} 'CodeEntry (:doc |)
+        |database $ %{} :CodeEntry (:doc |)
           :code $ quote
             def database $ {}
               :sessions $ do session ({})
@@ -1098,36 +1049,36 @@
               :today |2018-08-07
           :examples $ []
           :schema $ :: 'Dynamic
-        |note $ %{} 'CodeEntry (:doc |)
+        |note $ %{} :CodeEntry (:doc |)
           :code $ quote
             def note $ {} (:id nil) (:time nil) (:updated-time nil) (:text nil)
           :examples $ []
           :schema $ :: 'Dynamic
-        |notification $ %{} 'CodeEntry (:doc |)
+        |notification $ %{} :CodeEntry (:doc |)
           :code $ quote
             def notification $ {} (:id nil) (:kind nil) (:text nil)
           :examples $ []
           :schema $ :: 'Dynamic
-        |router $ %{} 'CodeEntry (:doc |)
+        |router $ %{} :CodeEntry (:doc |)
           :code $ quote
             def router $ {} (:name nil) (:title nil)
               :data $ {}
               :router nil
           :examples $ []
           :schema $ :: 'Dynamic
-        |session $ %{} 'CodeEntry (:doc |)
+        |session $ %{} :CodeEntry (:doc |)
           :code $ quote
             def session $ {} (:user-id nil) (:id nil) (:nickname nil)
               :router $ {} (:name :home) (:data nil) (:router nil)
               :messages $ {}
           :examples $ []
           :schema $ :: 'Dynamic
-        |task $ %{} 'CodeEntry (:doc |)
+        |task $ %{} :CodeEntry (:doc |)
           :code $ quote
             def task $ {} (:id nil) (:text |) (:detail |) (:pending? false) (:created-time nil) (:touched-time nil) (:finished-time nil) (:archived-time nil)
           :examples $ []
           :schema $ :: 'Dynamic
-        |user $ %{} 'CodeEntry (:doc |)
+        |user $ %{} :CodeEntry (:doc |)
           :code $ quote
             def user $ {} (:name nil) (:id nil) (:nickname nil) (:avatar nil) (:password nil)
               :tasks $ {}
@@ -1137,16 +1088,16 @@
               :notes $ do note ({})
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote (ns app.schema)
-    |app.server $ %{} 'FileEntry
+    |app.server $ %{} :FileEntry
       :defs $ {}
-        |*client-caches $ %{} 'CodeEntry (:doc |)
+        |*client-caches $ %{} :CodeEntry (:doc |)
           :code $ quote
             defatom *client-caches $ {}
           :examples $ []
           :schema $ :: 'Dynamic
-        |*initial-db $ %{} 'CodeEntry (:doc |)
+        |*initial-db $ %{} :CodeEntry (:doc |)
           :code $ quote
             defatom *initial-db $ if
               path-exists? $ w-log storage-file
@@ -1155,17 +1106,17 @@
               do (println "|Found no data") schema/database
           :examples $ []
           :schema $ :: 'Dynamic
-        |*reader-reel $ %{} 'CodeEntry (:doc |)
+        |*reader-reel $ %{} :CodeEntry (:doc |)
           :code $ quote (defatom *reader-reel @*reel)
           :examples $ []
           :schema $ :: 'Dynamic
-        |*reel $ %{} 'CodeEntry (:doc |)
+        |*reel $ %{} :CodeEntry (:doc |)
           :code $ quote
             defatom *reel $ merge reel-schema
               {} (:base @*initial-db) (:db @*initial-db)
           :examples $ []
           :schema $ :: 'Dynamic
-        |dispatch! $ %{} 'CodeEntry (:doc |)
+        |dispatch! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn dispatch! (op sid)
               let
@@ -1179,7 +1130,7 @@
                   _ $ reset! *reel (reel-reducer @*reel updater op sid op-id op-time config/dev?)
           :examples $ []
           :schema $ :: 'Dynamic
-        |get-backup-path! $ %{} 'CodeEntry (:doc |)
+        |get-backup-path! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn get-backup-path! () $ let
                 now $ extract-time (get-time!)
@@ -1188,7 +1139,7 @@
                 str (:day now) |-snapshot.cirru
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} 'CodeEntry (:doc |)
+        |main! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn main! ()
               println "|Running mode:" $ if config/dev? |dev |release
@@ -1204,12 +1155,12 @@
               set-interval 60000 $ fn () (set-today!)
           :examples $ []
           :schema $ :: 'Dynamic
-        |on-exit! $ %{} 'CodeEntry (:doc |)
+        |on-exit! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn on-exit! () (persist-db!) (; println "|exit code is...") (quit! 0)
           :examples $ []
           :schema $ :: 'Dynamic
-        |persist-db! $ %{} 'CodeEntry (:doc |)
+        |persist-db! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn persist-db! () $ let
                 file-content $ format-cirru-edn
@@ -1220,7 +1171,7 @@
               check-write-file! backup-path file-content
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} 'CodeEntry (:doc |)
+        |reload! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn reload! () (println "|Code updated..")
               if (not config/dev?) (raise "|reloading only happens in dev mode")
@@ -1229,7 +1180,7 @@
               sync-clients! @*reader-reel
           :examples $ []
           :schema $ :: 'Dynamic
-        |render-loop! $ %{} 'CodeEntry (:doc |)
+        |render-loop! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn render-loop! () $ when
               not $ identical? @*reader-reel @*reel
@@ -1237,7 +1188,7 @@
               sync-clients! @*reader-reel
           :examples $ []
           :schema $ :: 'Dynamic
-        |run-server! $ %{} 'CodeEntry (:doc |)
+        |run-server! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn run-server! (port)
               wss-serve! (&{} :port port)
@@ -1257,7 +1208,7 @@
                     _ $ println "|unknown data:" data
           :examples $ []
           :schema $ :: 'Dynamic
-        |set-today! $ %{} 'CodeEntry (:doc |)
+        |set-today! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn set-today! () $ let
                 today $ wo-log
@@ -1267,14 +1218,14 @@
                 dispatch! (:: :today today) |system
           :examples $ []
           :schema $ :: 'Dynamic
-        |storage-file $ %{} 'CodeEntry (:doc |)
+        |storage-file $ %{} :CodeEntry (:doc |)
           :code $ quote
             def storage-file $ if (empty? calcit-dirname)
               str calcit-dirname $ :storage-file config/site
               str calcit-dirname |/ $ :storage-file config/site
           :examples $ []
           :schema $ :: 'Dynamic
-        |sync-clients! $ %{} 'CodeEntry (:doc |)
+        |sync-clients! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn sync-clients! (reel)
               wss-each! $ fn (sid)
@@ -1294,7 +1245,7 @@
                       swap! *client-caches assoc sid new-store
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns app.server $ :require (app.schema :as schema)
             app.updater :refer $ updater
@@ -1309,29 +1260,29 @@
             calcit.std.time :refer $ set-interval
             calcit.std.date :refer $ get-time! extract-time format-time get-timestamp
             calcit.std.path :refer $ join-path
-    |app.style $ %{} 'FileEntry
+    |app.style $ %{} :FileEntry
       :defs $ {}
-        |button $ %{} 'CodeEntry (:doc |)
+        |button $ %{} :CodeEntry (:doc |)
           :code $ quote
             def button $ merge ui/button
               {} $ :background-color :white
           :examples $ []
           :schema $ :: 'Dynamic
-        |link $ %{} 'CodeEntry (:doc |)
+        |link $ %{} :CodeEntry (:doc |)
           :code $ quote
             def link $ {} (:text-decoration :underline) (:cursor :pointer)
               :color $ hsl 240 80 80
               :font-family ui/font-fancy
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns app.style $ :require
             [] respo-ui.core :refer $ [] hsl
             [] respo-ui.core :as ui
-    |app.twig.container $ %{} 'FileEntry
+    |app.twig.container $ %{} :FileEntry
       :defs $ {}
-        |twig-container $ %{} 'CodeEntry (:doc |)
+        |twig-container $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn twig-container (db session records)
               let
@@ -1360,7 +1311,7 @@
                   {}
           :examples $ []
           :schema $ :: 'Dynamic
-        |twig-members $ %{} 'CodeEntry (:doc |)
+        |twig-members $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn twig-members (sessions users)
               -> sessions $ .map-kv
@@ -1369,7 +1320,7 @@
                     [] (:user-id session) :name
           :examples $ []
           :schema $ :: 'Dynamic
-        |twig-notes-by-month $ %{} 'CodeEntry (:doc |)
+        |twig-notes-by-month $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn twig-notes-by-month (data notes)
               let
@@ -1385,7 +1336,7 @@
                         = month $ :month time
           :examples $ []
           :schema $ :: 'Dynamic
-        |twig-tasks-by-week $ %{} 'CodeEntry (:doc |)
+        |twig-tasks-by-week $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn twig-tasks-by-week (data tasks)
               let
@@ -1404,32 +1355,32 @@
                         &< t $ get-timestamp end-time
           :examples $ []
           :schema $ :: 'Dynamic
-        |week-millis $ %{} 'CodeEntry (:doc |)
+        |week-millis $ %{} :CodeEntry (:doc |)
           :code $ quote
             def week-millis $ * 7 24 3600 1000
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns app.twig.container $ :require
             [] app.twig.user :refer $ [] twig-user
             calcit.std.rand :refer $ rand-hex-color!
             calcit.std.date :refer $ Date extract-time get-time! from-ywd from-ymd parse-time format-time get-timestamp
-    |app.twig.user $ %{} 'FileEntry
+    |app.twig.user $ %{} :FileEntry
       :defs $ {}
-        |twig-user $ %{} 'CodeEntry (:doc |)
+        |twig-user $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn twig-user (user)
               -> user (dissoc :password) (dissoc :tasks)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns app.twig.user $ :require
             [] recollect.twig :refer $ [] deftwig
-    |app.updater $ %{} 'FileEntry
+    |app.updater $ %{} :FileEntry
       :defs $ {}
-        |updater $ %{} 'CodeEntry (:doc |)
+        |updater $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn updater (db op sid op-id op-time)
               tag-match op
@@ -1454,22 +1405,22 @@
                 _ $ do (eprintln "|Unknown op:" op) db
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns app.updater $ :require ([] app.updater.session :as session) ([] app.updater.user :as user) ([] app.updater.router :as router) ([] app.updater.misc :as misc) ([] app.updater.task :as task) ([] app.updater.note :as note) ([] app.schema :as schema)
             [] respo-message.updater :refer $ [] update-messages
-    |app.updater.misc $ %{} 'FileEntry
+    |app.updater.misc $ %{} :FileEntry
       :defs $ {}
-        |set-today $ %{} 'CodeEntry (:doc |)
+        |set-today $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn set-today (db op-data sid op-id op-time) (assoc db :today op-data)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote (ns app.updater.misc)
-    |app.updater.note $ %{} 'FileEntry
+    |app.updater.note $ %{} :FileEntry
       :defs $ {}
-        |add-note $ %{} 'CodeEntry (:doc |)
+        |add-note $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn add-note (db op-data sid op-id op-time)
               let
@@ -1480,7 +1431,7 @@
                 assoc-in db ([] :users user-id :notes op-id) new-note
           :examples $ []
           :schema $ :: 'Dynamic
-        |edit-note $ %{} 'CodeEntry (:doc |)
+        |edit-note $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn edit-note (db op-data sid op-id op-time)
               let
@@ -1492,7 +1443,7 @@
                   fn (note) (assoc note :text text)
           :examples $ []
           :schema $ :: 'Dynamic
-        |remove-note $ %{} 'CodeEntry (:doc |)
+        |remove-note $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn remove-note (db op-data sid op-id op-time)
               let
@@ -1502,35 +1453,35 @@
                   fn (notes) (dissoc notes op-data)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns app.updater.note $ :require ([] app.schema :as schema)
-    |app.updater.router $ %{} 'FileEntry
+    |app.updater.router $ %{} :FileEntry
       :defs $ {}
-        |change $ %{} 'CodeEntry (:doc |)
+        |change $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn change (db op-data sid op-id op-time)
               assoc-in db ([] :sessions sid :router) op-data
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote (ns app.updater.router)
-    |app.updater.session $ %{} 'FileEntry
+    |app.updater.session $ %{} :FileEntry
       :defs $ {}
-        |connect $ %{} 'CodeEntry (:doc |)
+        |connect $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn connect (db sid op-id op-time)
               assoc-in db ([] :sessions sid)
                 merge schema/session $ {} (:id sid)
           :examples $ []
           :schema $ :: 'Dynamic
-        |disconnect $ %{} 'CodeEntry (:doc |)
+        |disconnect $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn disconnect (db sid op-id op-time)
               update db :sessions $ fn (session) (dissoc session sid)
           :examples $ []
           :schema $ :: 'Dynamic
-        |remove-message $ %{} 'CodeEntry (:doc |)
+        |remove-message $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn remove-message (db op-data sid op-id op-time)
               update-in db ([] :sessions sid :messages)
@@ -1538,12 +1489,12 @@
                   dissoc messages $ :id op-data
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns app.updater.session $ :require ([] app.schema :as schema)
-    |app.updater.task $ %{} 'FileEntry
+    |app.updater.task $ %{} :FileEntry
       :defs $ {}
-        |create-working $ %{} 'CodeEntry (:doc |)
+        |create-working $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn create-working (db op-data sid op-id op-time)
               let
@@ -1552,7 +1503,7 @@
                   merge schema/task $ {} (:id op-id) (:text op-data) (:created-time op-time)
           :examples $ []
           :schema $ :: 'Dynamic
-        |finish-working $ %{} 'CodeEntry (:doc |)
+        |finish-working $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn finish-working (db op-data sid op-id op-time)
               let
@@ -1568,7 +1519,7 @@
                         , tasks
           :examples $ []
           :schema $ :: 'Dynamic
-        |pend $ %{} 'CodeEntry (:doc |)
+        |pend $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn pend (db op-data sid op-id op-time)
               let
@@ -1576,7 +1527,7 @@
                 update-in db ([] :users user-id :tasks :working op-data :pending?) not
           :examples $ []
           :schema $ :: 'Dynamic
-        |put-back $ %{} 'CodeEntry (:doc |)
+        |put-back $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn put-back (db op-data sid op-id op-time)
               let
@@ -1592,7 +1543,7 @@
                         , tasks
           :examples $ []
           :schema $ :: 'Dynamic
-        |remove-working $ %{} 'CodeEntry (:doc |)
+        |remove-working $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn remove-working (db op-data sid op-id op-time)
               let
@@ -1601,7 +1552,7 @@
                   fn (tasks) (dissoc tasks op-data)
           :examples $ []
           :schema $ :: 'Dynamic
-        |touch-working $ %{} 'CodeEntry (:doc |)
+        |touch-working $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn touch-working (db op-data sid op-id op-time)
               let
@@ -1611,7 +1562,7 @@
                     if (some? task) (assoc task :touched-time op-time) nil
           :examples $ []
           :schema $ :: 'Dynamic
-        |update-working $ %{} 'CodeEntry (:doc |)
+        |update-working $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn update-working (db op-data sid op-id op-time)
               let
@@ -1624,12 +1575,12 @@
                       , nil
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns app.updater.task $ :require ([] app.schema :as schema)
-    |app.updater.user $ %{} 'FileEntry
+    |app.updater.user $ %{} :FileEntry
       :defs $ {}
-        |log-in $ %{} 'CodeEntry (:doc |)
+        |log-in $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn log-in (db op-data sid op-id op-time)
               let-sugar
@@ -1652,13 +1603,13 @@
                           :text $ str "|No user named: " username
           :examples $ []
           :schema $ :: 'Dynamic
-        |log-out $ %{} 'CodeEntry (:doc |)
+        |log-out $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn log-out (db sid op-id op-time)
               assoc-in db ([] :sessions sid :user-id) nil
           :examples $ []
           :schema $ :: 'Dynamic
-        |sign-up $ %{} 'CodeEntry (:doc |)
+        |sign-up $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn sign-up (db op-data sid op-id op-time)
               let-sugar
@@ -1681,7 +1632,7 @@
                         :avatar nil
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} 'NsEntry (:doc |)
+      :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns app.updater.user $ :require
             [] cumulo-util.core :refer $ [] find-first

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,33 +1,46 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |app) (:version |0.1.0)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |app)
   :entries $ {}
     :default $ {} (:description "||Browser client bundle") (:init-fn 'app.client/main!) (:mode :js) (:reload-fn 'app.client/reload!)
-      :modules $ [] |lilac/ |recollect/ |memof/ |respo-ui.calcit/ |ws-edn.calcit/ |cumulo-util.calcit/ |respo-message.calcit/ |cumulo-reel.calcit/ |respo-feather.calcit/ |alerts.calcit/ |respo-markdown.calcit/ |respo.calcit/
+      :feature-policy $ {}
+      :modules $ [] |recollect/ |respo-ui.calcit/ |ws-edn.calcit/ |cumulo-util.calcit/ |respo-message.calcit/ |cumulo-reel.calcit/ |respo-feather.calcit/ |alerts.calcit/ |respo-markdown.calcit/ |respo.calcit/ |js-ffi/
       :type-slots $ {}
     :server $ {} (:description "||Realtime server") (:init-fn 'app.server/main!) (:mode :native) (:reload-fn 'app.server/reload!)
-      :modules $ [] |lilac/ |recollect/ |memof/ |cumulo-util.calcit/ |cumulo-reel.calcit/ |calcit.std/ |calcit-wss/
+      :feature-policy $ {}
+      :modules $ [] |recollect/ |cumulo-util.calcit/ |cumulo-reel.calcit/ |calcit.std/ |calcit-wss/
       :type-slots $ {}
   :files $ {}
-    |app.client $ %{} :FileEntry
+    |app.client $ %{} 'FileEntry
       :defs $ {}
-        |*states $ %{} :CodeEntry (:doc |)
+        |*states $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defatom *states $ {}
               :states $ {}
                 :cursor $ []
           :examples $ []
           :schema $ :: 'Dynamic
-        |*store $ %{} :CodeEntry (:doc |)
+        |*store $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defatom *store $ :: :initial
           :examples $ []
           :schema $ :: 'Dynamic
-        |connect! $ %{} :CodeEntry (:doc |)
+        |connect! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn connect! () $ let
-                url-obj $ url-parse js/location.href true
-                host $ either (-> url-obj .-query .-host) js/location.hostname
-                port $ either (-> url-obj .-query .-port) (:port config/site)
+                url-obj $ unsafe-coerce (url-parse js/location.href true) 'JsObject
+                query $ unsafe-coerce (.-query url-obj) 'JsObject
+                host $ unsafe-coerce
+                  if
+                    js-present? $ .-host query
+                    .-host query
+                    unsafe-coerce js/location.hostname 'String
+                  , 'String
+                port $ unsafe-coerce
+                  if
+                    js-present? $ .-port query
+                    .-port query
+                    :port config/site
+                  , 'String
               ws-connect!
                 if config/dev? (str |ws:// host |: port) |wss://timegrass.topix.im/ws
                 {}
@@ -38,7 +51,7 @@
                   :on-data on-server-data
           :examples $ []
           :schema $ :: 'Dynamic
-        |dispatch! $ %{} :CodeEntry (:doc |)
+        |dispatch! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn dispatch! (op)
               when
@@ -51,7 +64,7 @@
                 _ $ ws-send! op
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (.!extend dayjs week-of-year)
               println "|Running mode:" $ if config/dev? |dev |release
@@ -73,12 +86,12 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |mount-target $ %{} :CodeEntry (:doc |)
+        |mount-target $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def mount-target $ js/document.querySelector |.app
           :examples $ []
           :schema $ :: 'Dynamic
-        |on-server-data $ %{} :CodeEntry (:doc |)
+        |on-server-data $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn on-server-data (data)
               tag-match data
@@ -89,7 +102,7 @@
                 (:effect/pong) :ok
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ if
               or $ some? client-errors
@@ -100,24 +113,25 @@
                 println "|Code updated."
           :examples $ []
           :schema $ :: 'Dynamic
-        |render-app! $ %{} :CodeEntry (:doc |)
+        |render-app! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn render-app! () $ render! mount-target
-              comp-container (:states @*states) @*store
+              comp-container (&map:get @*states :states) @*store
               , dispatch!
           :examples $ []
           :schema $ :: 'Dynamic
-        |simulate-login! $ %{} :CodeEntry (:doc |)
+        |simulate-login! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn simulate-login! () $ let
                 raw $ js/localStorage.getItem (:storage-key config/site)
-              if (some? raw)
+              if (js-present? raw)
                 do (println "|Found storage.")
-                  dispatch! $ :: :user/log-in (parse-cirru-edn raw)
+                  dispatch! $ :: :user/log-in
+                    parse-cirru-edn $ unsafe-coerce raw 'String
                 do $ println "|Found no storage."
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.client $ :require
             respo.core :refer $ render! clear-cache! realize-ssr!
@@ -133,45 +147,43 @@
             |./calcit.build-errors :default client-errors
             |dayjs :default dayjs
             |dayjs/plugin/weekOfYear :default week-of-year
-    |app.comp.container $ %{} :FileEntry
+    |app.comp.container $ %{} 'FileEntry
       :defs $ {}
-        |comp-container $ %{} :CodeEntry (:doc |)
+        |comp-container $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn comp-container (states store)
               case-default store
                 let
-                    state $ :data states
-                    session $ :session store
-                    router $ :router store
-                    router-data $ :data router
+                    state $ &map:get states :data
+                    session $ &map:get store :session
+                    router $ &map:get store :router
+                    router-data $ &map:get router :data
                   div
                     {} $ :class-name css-container
-                    comp-navigation (:logged-in? store) (:count store) (:name router)
-                    if (:logged-in? store)
-                      case-default (:name router)
+                    comp-navigation (&map:get store :logged-in?) (&map:get store :count) (&map:get router :name)
+                    if (&map:get store :logged-in?)
+                      case-default (&map:get router :name)
                         <> $ str "|404 page:" router
-                        :home $ comp-overview (>> states :overview) (:today store)
+                        :home $ comp-overview (>> states :overview) (&map:get store :today)
                           get-in router $ [] :data :tasks
                         :history $ comp-history (>> states :history)
                           get-in router $ [] :data :week
                           get-in router $ [] :data :tasks
-                        :notes $ comp-notes-page (>> states :notes) (:data router)
+                        :notes $ comp-notes-page (>> states :notes) (&map:get router :data)
                           get-in session $ [] :router :data
-                        :profile $ comp-profile (:user store) (:data router)
+                        :profile $ comp-profile (&map:get store :user) (&map:get router :data)
                       comp-login $ >> states :login
-                    comp-status-color $ :color store
+                    comp-status-color $ &map:get store :color
                     when dev? $ comp-inspect |Store store
                       {} (:bottom 0) (:left 0) (:z-index 9999)
-                    comp-messages
-                      get-in store $ [] :session :messages
-                      {}
+                    comp-messages (&map:get session :messages) ({})
                       fn (info d!) (d! :session/remove-message info)
-                    when dev? $ comp-reel (:reel-length store) ({})
+                    when dev? $ comp-reel (&map:get store :reel-length) ({})
                 (:: :initial) (comp-offline :initial)
                 (:: :offline) (comp-offline :offline)
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-offline $ %{} :CodeEntry (:doc |)
+        |comp-offline $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-offline (state)
               div
@@ -193,39 +205,39 @@
                     {} (:font-family ui/font-fancy) (:font-weight 100) (:font-size 24)
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-status-color $ %{} :CodeEntry (:doc |)
+        |comp-status-color $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-status-color (color)
               div $ {} (:class-name css-status-color)
                 :style $ {} (:background-color color)
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-container $ %{} :CodeEntry (:doc |)
+        |css-container $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-container $ {}
               |$0 $ merge ui/global ui/fullscreen ui/column
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-offline $ %{} :CodeEntry (:doc |)
+        |css-offline $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-offline $ {}
               |$0 $ merge ui/global ui/fullscreen ui/column-dispersive
                 {} $ :background-color (:theme config/site)
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-status-color $ %{} :CodeEntry (:doc |)
+        |css-status-color $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-status-color $ {}
               |$0 $ {} (:width 16) (:height 16) (:position :absolute) (:bottom 16) (:right 8) (:border-radius |8px) (:opacity 0.8) (:transition-duration |200ms) (:opacity 0.5)
               |$0:hover $ {} (:opacity 0.7)
           :examples $ []
           :schema $ :: 'Dynamic
-        |style-body $ %{} :CodeEntry (:doc |)
+        |style-body $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def style-body $ {} (:padding "|8px 16px")
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.comp.container $ :require
             hsl.core :refer $ hsl
@@ -246,26 +258,29 @@
             app.config :as config
             app.comp.history :refer $ comp-history
             app.comp.notes-page :refer $ comp-notes-page
-    |app.comp.history $ %{} :FileEntry
+    |app.comp.history $ %{} 'FileEntry
       :defs $ {}
-        |comp-done-task $ %{} :CodeEntry (:doc |)
+        |comp-done-task $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-done-task (states task)
               let
-                  cursor $ :cursor states
-                  state $ or (:data states)
+                  cursor $ &map:get states :cursor
+                  state $ or (&map:get states :data)
                     {} $ :show-menu? false
+                  finished-day $ unsafe-coerce
+                    dayjs $ &map:get task :finished-time
+                    , 'JsObject
                 div
                   {} (:class-name css-done-task)
                     :style $ merge
                       {} $ :padding "|4px 8px"
-                      if (:show-menu? state)
+                      if (&map:get state :show-menu?)
                         {} $ :background-color (hsl 0 0 94)
                         {}
                     :on-click $ fn (e d!)
                       d! cursor $ assoc state :show-menu? true
                   <>
-                    -> (:finished-time task) dayjs $ .!format |HH:mm
+                    unsafe-coerce (.!format finished-day |HH:mm) 'String
                     {} (:min-width 32)
                       :color $ hsl 0 0 80
                       :font-size 12
@@ -274,27 +289,27 @@
                   span
                     {} $ :style
                       merge ui/flex $ {} (:line-height |24px)
-                    <> $ :text task
+                    <> $ &map:get task :text
                   comp-modal-menu
                     {} (:title |Operations)
                       :style $ {} (:width 320)
                       :items $ [] (:: :item :put-back "|Put back")
-                    :show-menu? state
+                    &map:get state :show-menu?
                     fn (d!)
                       d! cursor $ assoc state :show-menu? false
                     fn (item d!)
                       d! cursor $ assoc state :show-menu? false
                       when
-                        = :put-back $ nth item 1
-                        d! :task/put-back $ :id task
+                        = :put-back $ option:unwrap-or (nth item 1) nil
+                        d! :task/put-back $ &map:get task :id
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-history $ %{} :CodeEntry (:doc |)
+        |comp-history $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-history (states data finished-tasks)
               let
-                  year $ :year data
-                  week $ :week data
+                  year $ &map:get data :year
+                  week $ &map:get data :week
                 div
                   {} (:class-name css/flex)
                     :style $ {} (:padding "|16px 16px") (:overflow :auto)
@@ -319,10 +334,14 @@
                                   change-year? $ <= week 1
                                   y $ if change-year? (dec year) year
                                   w $ if change-year? 53 (dec week)
-                                  d $ -> (dayjs) (.!year y) (.!week w)
+                                  base-day $ unsafe-coerce (dayjs) 'JsObject
+                                  year-day $ unsafe-coerce (.!year base-day y) 'JsObject
+                                  d $ unsafe-coerce (.!week year-day w) 'JsObject
+                                  start-day $ unsafe-coerce (.!startOf d |week) 'JsObject
+                                  end-day $ unsafe-coerce (.!endOf d |week) 'JsObject
                                 {} (:year y) (:week w)
-                                  :start $ .!format (.!startOf d |week)
-                                  :end $ .!format (.!endOf d |week)
+                                  :start $ unsafe-coerce (.!format start-day |week) 'String
+                                  :end $ unsafe-coerce (.!format end-day |week) 'String
                         =< 8 nil
                         comp-icon :arrow-right
                           {} (:font-size 16)
@@ -334,10 +353,14 @@
                                   change-year? $ >= week 53
                                   y $ if change-year? (inc year) year
                                   w $ if change-year? 1 (inc week)
-                                  d $ -> (dayjs) (.!year y) (.!week w)
+                                  base-day $ unsafe-coerce (dayjs) 'JsObject
+                                  year-day $ unsafe-coerce (.!year base-day y) 'JsObject
+                                  d $ unsafe-coerce (.!week year-day w) 'JsObject
+                                  start-day $ unsafe-coerce (.!startOf d |week) 'JsObject
+                                  end-day $ unsafe-coerce (.!endOf d |week) 'JsObject
                                 {} (:year y) (:week w)
-                                  :start $ .!format (.!startOf d |week)
-                                  :end $ .!format (.!endOf d |week)
+                                  :start $ unsafe-coerce (.!format start-day |week) 'String
+                                  :end $ unsafe-coerce (.!format end-day |week) 'String
                     if (empty? finished-tasks)
                       div
                         {} (:class-name css/center)
@@ -347,39 +370,45 @@
                       let
                           grouped-tasks $ -> finished-tasks (.to-list) (.map last)
                             group-by $ fn (task)
-                              .!format
-                                dayjs $ :finished-time task
-                                , |YYYY-MM-DD
+                              unsafe-coerce
+                                .!format
+                                  unsafe-coerce
+                                    dayjs $ &map:get task :finished-time
+                                    , 'JsObject
+                                  , |YYYY-MM-DD
+                                , 'String
                         list-> ({})
                           -> grouped-tasks (.to-list)
                             .sort $ fn (x y)
-                              &compare (first y) (first x)
+                              &compare
+                                option:unwrap-or (first y) |
+                                option:unwrap-or (first x) |
                             .map-pair $ fn (date-string task-list)
                               [] date-string $ div
                                 {} (:class-name css/column)
                                   :style $ {} (:margin-top 16)
                                 let
-                                    the-day $ dayjs date-string
+                                    the-day $ unsafe-coerce (dayjs date-string) 'JsObject
                                   div
                                     {} $ :class-name css/row-parted
                                     span
                                       {} $ :class-name css/font-fancy
-                                      <> $ .!format the-day |ddd
+                                      <> $ unsafe-coerce (.!format the-day |ddd) 'String
                                       =< 12 nil
-                                      <> $ .!format the-day |MM-DD
+                                      <> $ unsafe-coerce (.!format the-day |MM-DD) 'String
                                 =< nil 4
                                 list-> ({})
                                   -> task-list
                                     .sort-by $ fn (task)
-                                      negate $ :finished-time task
+                                      negate $ &map:get task :finished-time
                                     .map $ fn (task)
-                                      [] (:id task)
+                                      [] (&map:get task :id)
                                         comp-done-task
-                                          >> states $ :id task
+                                          >> states $ &map:get task :id
                                           , task
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-done-task $ %{} :CodeEntry (:doc |)
+        |css-done-task $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-done-task $ {}
               |$0 $ {} (:transition-duration |200ms)
@@ -387,7 +416,7 @@
                 :background-color $ hsl 0 0 80 0.2
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.comp.history $ :require
             respo-ui.core :refer $ hsl
@@ -400,14 +429,14 @@
             respo-alerts.core :refer $ comp-modal-menu
             |dayjs :default dayjs
             feather.core :refer $ comp-icon
-    |app.comp.login $ %{} :FileEntry
+    |app.comp.login $ %{} 'FileEntry
       :defs $ {}
-        |comp-login $ %{} :CodeEntry (:doc |)
+        |comp-login $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-login (states)
               let
-                  cursor $ :cursor states
-                  state $ or (:data states) initial-state
+                  cursor $ &map:get states :cursor
+                  state $ or (&map:get states :data) initial-state
                 div
                   {} $ :style (merge ui/flex ui/center)
                   div ({})
@@ -415,38 +444,38 @@
                       {} $ :style ({})
                       div ({})
                         input $ {} (:placeholder |Username)
-                          :value $ :username state
+                          :value $ &map:get state :username
                           :style ui/input
                           :on-input $ fn (e d!)
                             d! cursor $ assoc state :username
-                              str $ :value e
+                              str $ &map:get e :value
                       =< nil 8
                       div ({})
                         input $ {} (:placeholder |Password)
-                          :value $ :password state
+                          :value $ &map:get state :password
                           :style ui/input
                           :on-input $ fn (e d!)
                             d! cursor $ assoc state :password
-                              str $ :value e
+                              str $ &map:get e :value
                     =< nil 8
                     div
                       {} $ :style
                         {} $ :text-align :right
                       span $ {} (:inner-text "|Sign up")
                         :style $ merge style/link
-                        :on-click $ on-submit (:username state) (:password state) true
+                        :on-click $ on-submit (&map:get state :username) (&map:get state :password) true
                       =< 8 nil
                       span $ {} (:inner-text "|Log in")
                         :style $ merge style/link
-                        :on-click $ on-submit (:username state) (:password state) false
+                        :on-click $ on-submit (&map:get state :username) (&map:get state :password) false
           :examples $ []
           :schema $ :: 'Dynamic
-        |initial-state $ %{} :CodeEntry (:doc |)
+        |initial-state $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def initial-state $ {} (:username |) (:password |)
           :examples $ []
           :schema $ :: 'Dynamic
-        |on-submit $ %{} :CodeEntry (:doc |)
+        |on-submit $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn on-submit (username password signup?)
               fn (e dispatch!)
@@ -455,7 +484,7 @@
                   format-cirru-edn $ [] username password
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.comp.login $ :require
             [] respo.core :refer $ [] defcomp <> div input button span
@@ -465,9 +494,9 @@
             [] app.schema :as schema
             [] app.style :as style
             [] app.config :as config
-    |app.comp.navigation $ %{} :FileEntry
+    |app.comp.navigation $ %{} 'FileEntry
       :defs $ {}
-        |comp-navigation $ %{} :CodeEntry (:doc |)
+        |comp-navigation $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-navigation (logged-in? count-members page)
               div
@@ -484,20 +513,22 @@
                     render-entry |Finished
                       fn () $ {} (:name :history)
                         :data $ let
-                            now $ dayjs
+                            now $ unsafe-coerce (dayjs) 'JsObject
                             month $ .!month now
-                            week-date now
+                            week-date $ unsafe-coerce now 'JsObject
+                            start-day $ unsafe-coerce (.!startOf week-date |week) 'JsObject
+                            end-day $ unsafe-coerce (.!endOf week-date |week) 'JsObject
                           {}
                             :year $ .!year now
                             :week $ .!week week-date
-                            :start $ .!format (.!startOf week-date |week)
-                            :end $ .!format (.!endOf week-date |week)
+                            :start $ unsafe-coerce (.!format start-day |week) 'String
+                            :end $ unsafe-coerce (.!format end-day |week) 'String
                       = page :history
                     =< 16 nil
                     render-entry |Notes
                       fn () $ {} (:name :notes)
                         :data $ let
-                            now $ dayjs
+                            now $ unsafe-coerce (dayjs) 'JsObject
                           {}
                             :year $ .!year now
                             :month $ .!month now
@@ -513,14 +544,14 @@
                     <> count-members
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-entry $ %{} :CodeEntry (:doc |)
+        |css-entry $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-entry $ {}
               |$0 $ {} (:opacity 0.6) (:user-select :none) (:transition-duration |200ms)
               |$0:hover $ {} (:opacity 0.8)
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-navbar $ %{} :CodeEntry (:doc |)
+        |css-navbar $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-navbar $ {}
               |$0 $ merge ui/row-center
@@ -531,7 +562,7 @@
                   :color :white
           :examples $ []
           :schema $ :: 'Dynamic
-        |render-entry $ %{} :CodeEntry (:doc |)
+        |render-entry $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn render-entry (title get-route highlighted?)
               div
@@ -545,7 +576,7 @@
                 <> title nil
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.comp.navigation $ :require
             respo-ui.core :refer $ hsl
@@ -557,17 +588,20 @@
             app.config :as config
             respo-alerts.core :refer $ comp-prompt
             |dayjs :default dayjs
-    |app.comp.notes-page $ %{} :FileEntry
+    |app.comp.notes-page $ %{} 'FileEntry
       :defs $ {}
-        |comp-note $ %{} :CodeEntry (:doc |)
+        |comp-note $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-note (states note)
               let
                   edit-plugin $ use-prompt (>> states :edit)
                     {} (:text "|Update note:") (:multiline? true)
-                      :initial $ :text note
+                      :initial $ &map:get note :text
                   remove-plugin $ use-confirm (>> states :remove)
                     {} $ :text "|Sure to delete note?"
+                  note-day $ unsafe-coerce
+                    dayjs $ &map:get note :time
+                    , 'JsObject
                 div
                   {}
                     :class-name $ str-spaced css/column css-note
@@ -577,7 +611,7 @@
                   div
                     {} $ :class-name css/row-parted
                     <>
-                      -> (:time note) dayjs $ .!format |HH:mm
+                      unsafe-coerce (.!format note-day |HH:mm) 'String
                       {} (:font-family ui/font-fancy)
                         :color $ hsl 0 0 70
                         :font-size 12
@@ -589,25 +623,25 @@
                         fn (e d!)
                           .show edit-plugin d! $ fn (result)
                             d! :note/edit $ {}
-                              :id $ :id note
+                              :id $ &map:get note :id
                               :text result
                       =< 8 nil
                       comp-icon :delete
                         &{} :font-size 16 :cursor :pointer :color $ hsl 10 80 60
                         fn (e d!)
                           .show remove-plugin d! $ fn ()
-                            d! :note/remove $ :id note
-                  <> $ :text note
+                            d! :note/remove $ &map:get note :id
+                  <> $ &map:get note :text
                   .render edit-plugin
                   .render remove-plugin
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-notes-page $ %{} :CodeEntry (:doc |)
+        |comp-notes-page $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-notes-page (states notes info)
               let
-                  year $ :year info
-                  month $ :month info
+                  year $ &map:get info :year
+                  month $ &map:get info :month
                   add-plugin $ use-prompt (>> states :add)
                     {} (:text "|Add note about today's work:") (:multiline? true)
                 div
@@ -671,12 +705,19 @@
                       let
                           grouped-notes $ -> notes (.to-list)
                             .group-by $ fn (pair)
-                              ->
-                                :time $ last pair
-                                , dayjs $ .!format |MM-DD
+                              let
+                                  pair-value $ unsafe-coerce (nth pair 1) 'Dynamic
+                                  note-time $ &map:get pair-value :time
+                                unsafe-coerce
+                                  .!format
+                                    unsafe-coerce (dayjs note-time) 'JsObject
+                                    , |MM-DD
+                                  , 'String
                             .to-list
                             .sort $ fn (x y)
-                              &compare (first y) (first x)
+                              &compare
+                                option:unwrap-or (first y) |
+                                option:unwrap-or (first x) |
                         list-> ({})
                           -> grouped-notes (.to-list)
                             .map-pair $ fn (date notes-in-day)
@@ -686,21 +727,29 @@
                                 div
                                   {} (:class-name css/font-fancy)
                                     :style $ {} (:font-size 14) (:font-weight 500)
-                                  <> $ -> (str year |- date) dayjs (.!format |ddd)
+                                  <> $ unsafe-coerce
+                                    .!format
+                                      unsafe-coerce
+                                        dayjs $ str year |- date
+                                        , 'JsObject
+                                      , |ddd
+                                    , 'String
                                   =< 12 nil
                                   <> $ str date
                                 list->
                                   {} $ :class-name css/column
                                   -> notes-in-day
                                     .sort-by $ fn (pair)
-                                      negate $ :time (last pair)
+                                      let
+                                          note-value $ unsafe-coerce (nth pair 1) 'Dynamic
+                                        negate $ &map:get note-value :time
                                     .map-pair $ fn (k note)
                                       [] k $ comp-note (>> states k) note
                     =< nil 160
                   .render add-plugin
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-note $ %{} :CodeEntry (:doc |)
+        |css-note $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-note $ {}
               |$0 $ {} (:transition-duration |200ms)
@@ -708,7 +757,7 @@
                 :background-color $ hsl 0 0 80 0.2
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.comp.notes-page $ :require
             respo-ui.core :refer $ hsl
@@ -722,9 +771,16 @@
             respo-alerts.core :refer $ use-prompt use-confirm
             feather.core :refer $ comp-i comp-icon
             |dayjs :default dayjs
-    |app.comp.overview $ %{} :FileEntry
+    |app.comp.overview $ %{} 'FileEntry
       :defs $ {}
-        |comp-no-tasks $ %{} :CodeEntry (:doc |)
+        |comp-global-keydown $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defcomp comp-global-keydown (options on-event)
+              span $ {}
+                :on-keydown $ fn (e d!) (on-event e d!)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |comp-no-tasks $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-no-tasks () $ div
               {}
@@ -734,21 +790,22 @@
               <> "|No tasks"
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-overview $ %{} :CodeEntry (:doc |)
+        |comp-overview $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-overview (states today tasks)
               let
                   working-tasks $ -> tasks (.to-map)
                     filter $ fn (pair)
-                      not $ :pending? (last pair)
+                      not $ &map:get (last pair) :pending?
                   pending-tasks $ -> tasks (.to-map)
                     filter $ fn (pair)
-                      :pending? $ last pair
+                      &map:get (last pair) :pending?
                   create-plugin $ use-prompt (>> states :create)
                     {} $ :text "|Create new task:"
-                  cursor $ :cursor states
-                  state $ or (:data states)
+                  cursor $ &map:get states :cursor
+                  state $ or (&map:get states :data)
                     {} $ :show-later? false
+                  today-day $ unsafe-coerce (dayjs today) 'JsObject
                 div
                   {} (:class-name css/expand)
                     :style $ {} (:padding 16)
@@ -764,19 +821,17 @@
                       comp-global-keydown ({})
                         fn (e d!)
                           if
-                            and (:meta? e)
-                              = |i $ :key e
+                            and (&map:get e :meta?)
+                              = |i $ &map:get e :key
                             .show create-plugin d! $ fn (result) (d! :task/create-working result)
                       div
                         {}
                           :class-name $ str-spaced css/row-middle css/font-fancy
                           :style $ {}
                             :color $ hsl 0 0 60
-                        <> $ .!format (dayjs today) |ddd
+                        <> $ unsafe-coerce (.!format today-day |ddd) 'String
                         =< 8 nil
-                        <> $ str
-                          .!week $ dayjs today
-                          , "|th week"
+                        <> $ str (.!week today-day) "|th week"
                         =< 16 nil
                         <> today
                     if (empty? working-tasks) (comp-no-tasks)
@@ -785,26 +840,26 @@
                           .sort-by $ fn (pair)
                             let
                                 task $ last pair
-                              negate $ or (:touched-time task) (:created-time task)
+                              negate $ or (&map:get task :touched-time) (&map:get task :created-time)
                           .map-pair $ fn (k task)
                             [] k $ comp-task
-                              >> states $ :id task
+                              >> states $ &map:get task :id
                               , task :working
                     when
                       not $ empty? pending-tasks
                       div ({})
                         comp-title |Later nil $ fn (e d!)
                           d! cursor $ update state :show-later? not
-                        if (:show-later? state)
+                        if (&map:get state :show-later?)
                           list-> ({})
                             -> pending-tasks (.to-list)
                               .sort-by $ fn (pair)
                                 let
                                     task $ last pair
-                                  negate $ or (:touched-time task) (:created-time task)
+                                  negate $ or (&map:get task :touched-time) (&map:get task :created-time)
                               .map-pair $ fn (k task)
                                 [] k $ comp-task
-                                  >> states $ :id task
+                                  >> states $ &map:get task :id
                                   , task :pending
                           div
                             {}
@@ -817,16 +872,16 @@
                     .render create-plugin
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-task $ %{} :CodeEntry (:doc |)
+        |comp-task $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-task (states task mode)
               let
-                  cursor $ :cursor states
-                  state $ or (:data states)
+                  cursor $ &map:get states :cursor
+                  state $ or (&map:get states :data)
                     {} $ :menu? false
                   update-plugin $ use-prompt (>> states :drafter)
                     {} (:text "|Task content:")
-                      :initial $ :text task
+                      :initial $ &map:get task :text
                       :placeholder |task...
                       :button-text |Edit
                   delete-plugin $ use-confirm (>> states :delete)
@@ -834,18 +889,18 @@
                 div
                   {} (:class-name css-task-base)
                     :style $ merge
-                      if (:menu? state)
+                      if (&map:get state :menu?)
                         {} $ :background-color (hsl 0 0 94)
                         {}
                     :on-click $ fn (e d!)
                       d! cursor $ assoc state :menu? true
                     :on $ {}
                       :dragend $ fn (e d!)
-                        d! :task/touch-working $ :id task
+                        d! :task/touch-working $ &map:get task :id
                     :draggable true
                   div
                     {} $ :style ui/flex
-                    <> (:text task) ({})
+                    <> (&map:get task :text) ({})
                   comp-modal-menu
                     {} (:title |Operations)
                       :style $ {} (:width 320)
@@ -855,7 +910,7 @@
                         :: :item :copy |Copy
                         :: :item :edit |Edit
                         :: :item :remove |Remove
-                    :menu? state
+                    &map:get state :menu?
                     fn (d!)
                       d! cursor $ assoc state :menu? false
                     fn (item d!)
@@ -865,30 +920,30 @@
                         js/console.log item
                         case-default result (d! cursor new-state)
                           :done $ do
-                            d! :task/finish-working $ :id task
+                            d! :task/finish-working $ &map:get task :id
                             d! cursor new-state
                           :edit $ do (d! cursor new-state)
                             .show update-plugin d! $ fn (text)
                               d! :task/update-working $ {}
-                                :id $ :id task
+                                :id $ &map:get task :id
                                 :text text
                           :copy $ do
-                            copy! $ :text task
+                            copy! $ &map:get task :text
                             d! cursor new-state
                           :remove $ do (d! cursor new-state)
                             .show delete-plugin d! $ fn ()
-                              d! :task/remove-working $ :id task
+                            d! :task/remove-working $ &map:get task :id
                           :pend $ do
-                            d! :task/pend $ :id task
+                            d! :task/pend $ &map:get task :id
                             d! cursor new-state
                           :touch $ do
-                            d! :task/touch-working $ :id task
+                            d! :task/touch-working $ &map:get task :id
                             d! cursor new-state
                   .render update-plugin
                   .render delete-plugin
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-title $ %{} :CodeEntry (:doc |)
+        |comp-title $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-title (title child ? on-click)
               div
@@ -902,7 +957,7 @@
                 , child
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-task-base $ %{} :CodeEntry (:doc |)
+        |css-task-base $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-task-base $ {}
               |$0 $ {}
@@ -916,7 +971,7 @@
                 :background-color $ hsl 0 0 80 0.1
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-title $ %{} :CodeEntry (:doc |)
+        |css-title $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-title $ {}
               |$0 $ merge ui/row-middle
@@ -926,7 +981,7 @@
                   :font-weight 300
           :examples $ []
           :schema $ :: 'Dynamic
-        |effect-focus $ %{} :CodeEntry (:doc |)
+        |effect-focus $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defeffect effect-focus () (action el *local)
               case action
@@ -934,7 +989,7 @@
                 do
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.comp.overview $ :require
             respo-ui.core :refer $ hsl
@@ -950,10 +1005,9 @@
             feather.core :refer $ comp-i comp-icon
             |dayjs :default dayjs
             |copy-text-to-clipboard :default copy!
-            respo.comp.global-keydown :refer $ comp-global-keydown
-    |app.comp.profile $ %{} :FileEntry
+    |app.comp.profile $ %{} 'FileEntry
       :defs $ {}
-        |comp-profile $ %{} :CodeEntry (:doc |)
+        |comp-profile $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-profile (user members)
               div
@@ -965,7 +1019,7 @@
                   div
                     {} (:class-name css/font-fancy)
                       :style $ {} (:font-size 32) (:font-weight 100)
-                    <> $ str "|Hello! " (:name user)
+                    <> $ str "|Hello! " (&map:get user :name)
                   =< nil 16
                   div
                     {} $ :class-name css/row
@@ -994,7 +1048,7 @@
                       <> "|Log out"
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-member-label $ %{} :CodeEntry (:doc |)
+        |css-member-label $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-member-label $ {}
               |$0 $ {} (:padding "|0 8px")
@@ -1003,7 +1057,7 @@
                 :margin "|0 4px"
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.comp.profile $ :require
             respo-ui.core :refer $ hsl
@@ -1014,28 +1068,29 @@
             respo.css :refer $ defstyle
             respo.comp.space :refer $ =<
             app.config :as config
-    |app.config $ %{} :FileEntry
+    |app.config $ %{} 'FileEntry
       :defs $ {}
-        |dev? $ %{} :CodeEntry (:doc |)
+        |dev? $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            def dev? $ = |dev (get-env |mode |release)
+            def dev? $ = |dev
+              option:unwrap-or (get-env |mode) |release
           :examples $ []
           :schema $ :: 'Dynamic
-        |site $ %{} :CodeEntry (:doc |)
+        |site $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def site $ {} (:port 11009) (:title |Timegrass) (:icon |http://cdn.tiye.me/logo/timegrass.png) (:dev-ui |http://localhost:8100/main.css) (:release-ui |http://cdn.tiye.me/favored-fonts/main.css) (:cdn-url |http://cdn.tiye.me/timegrass/) (:theme |#51C766) (:storage-key |timegrass) (:storage-file |storage.cirru)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.config)
-    |app.schema $ %{} :FileEntry
+    |app.schema $ %{} 'FileEntry
       :defs $ {}
-        |complain $ %{} :CodeEntry (:doc |)
+        |complain $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def complain $ {} (:id nil) (:text |) (:time nil)
           :examples $ []
           :schema $ :: 'Dynamic
-        |database $ %{} :CodeEntry (:doc |)
+        |database $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def database $ {}
               :sessions $ do session ({})
@@ -1043,36 +1098,36 @@
               :today |2018-08-07
           :examples $ []
           :schema $ :: 'Dynamic
-        |note $ %{} :CodeEntry (:doc |)
+        |note $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def note $ {} (:id nil) (:time nil) (:updated-time nil) (:text nil)
           :examples $ []
           :schema $ :: 'Dynamic
-        |notification $ %{} :CodeEntry (:doc |)
+        |notification $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def notification $ {} (:id nil) (:kind nil) (:text nil)
           :examples $ []
           :schema $ :: 'Dynamic
-        |router $ %{} :CodeEntry (:doc |)
+        |router $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def router $ {} (:name nil) (:title nil)
               :data $ {}
               :router nil
           :examples $ []
           :schema $ :: 'Dynamic
-        |session $ %{} :CodeEntry (:doc |)
+        |session $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def session $ {} (:user-id nil) (:id nil) (:nickname nil)
               :router $ {} (:name :home) (:data nil) (:router nil)
               :messages $ {}
           :examples $ []
           :schema $ :: 'Dynamic
-        |task $ %{} :CodeEntry (:doc |)
+        |task $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def task $ {} (:id nil) (:text |) (:detail |) (:pending? false) (:created-time nil) (:touched-time nil) (:finished-time nil) (:archived-time nil)
           :examples $ []
           :schema $ :: 'Dynamic
-        |user $ %{} :CodeEntry (:doc |)
+        |user $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def user $ {} (:name nil) (:id nil) (:nickname nil) (:avatar nil) (:password nil)
               :tasks $ {}
@@ -1082,16 +1137,16 @@
               :notes $ do note ({})
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.schema)
-    |app.server $ %{} :FileEntry
+    |app.server $ %{} 'FileEntry
       :defs $ {}
-        |*client-caches $ %{} :CodeEntry (:doc |)
+        |*client-caches $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defatom *client-caches $ {}
           :examples $ []
           :schema $ :: 'Dynamic
-        |*initial-db $ %{} :CodeEntry (:doc |)
+        |*initial-db $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defatom *initial-db $ if
               path-exists? $ w-log storage-file
@@ -1100,17 +1155,17 @@
               do (println "|Found no data") schema/database
           :examples $ []
           :schema $ :: 'Dynamic
-        |*reader-reel $ %{} :CodeEntry (:doc |)
+        |*reader-reel $ %{} 'CodeEntry (:doc |)
           :code $ quote (defatom *reader-reel @*reel)
           :examples $ []
           :schema $ :: 'Dynamic
-        |*reel $ %{} :CodeEntry (:doc |)
+        |*reel $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defatom *reel $ merge reel-schema
               {} (:base @*initial-db) (:db @*initial-db)
           :examples $ []
           :schema $ :: 'Dynamic
-        |dispatch! $ %{} :CodeEntry (:doc |)
+        |dispatch! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn dispatch! (op sid)
               let
@@ -1124,7 +1179,7 @@
                   _ $ reset! *reel (reel-reducer @*reel updater op sid op-id op-time config/dev?)
           :examples $ []
           :schema $ :: 'Dynamic
-        |get-backup-path! $ %{} :CodeEntry (:doc |)
+        |get-backup-path! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn get-backup-path! () $ let
                 now $ extract-time (get-time!)
@@ -1133,7 +1188,7 @@
                 str (:day now) |-snapshot.cirru
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! ()
               println "|Running mode:" $ if config/dev? |dev |release
@@ -1149,12 +1204,12 @@
               set-interval 60000 $ fn () (set-today!)
           :examples $ []
           :schema $ :: 'Dynamic
-        |on-exit! $ %{} :CodeEntry (:doc |)
+        |on-exit! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn on-exit! () (persist-db!) (; println "|exit code is...") (quit! 0)
           :examples $ []
           :schema $ :: 'Dynamic
-        |persist-db! $ %{} :CodeEntry (:doc |)
+        |persist-db! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn persist-db! () $ let
                 file-content $ format-cirru-edn
@@ -1165,7 +1220,7 @@
               check-write-file! backup-path file-content
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () (println "|Code updated..")
               if (not config/dev?) (raise "|reloading only happens in dev mode")
@@ -1174,7 +1229,7 @@
               sync-clients! @*reader-reel
           :examples $ []
           :schema $ :: 'Dynamic
-        |render-loop! $ %{} :CodeEntry (:doc |)
+        |render-loop! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn render-loop! () $ when
               not $ identical? @*reader-reel @*reel
@@ -1182,7 +1237,7 @@
               sync-clients! @*reader-reel
           :examples $ []
           :schema $ :: 'Dynamic
-        |run-server! $ %{} :CodeEntry (:doc |)
+        |run-server! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn run-server! (port)
               wss-serve! (&{} :port port)
@@ -1202,7 +1257,7 @@
                     _ $ println "|unknown data:" data
           :examples $ []
           :schema $ :: 'Dynamic
-        |set-today! $ %{} :CodeEntry (:doc |)
+        |set-today! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn set-today! () $ let
                 today $ wo-log
@@ -1212,14 +1267,14 @@
                 dispatch! (:: :today today) |system
           :examples $ []
           :schema $ :: 'Dynamic
-        |storage-file $ %{} :CodeEntry (:doc |)
+        |storage-file $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def storage-file $ if (empty? calcit-dirname)
               str calcit-dirname $ :storage-file config/site
               str calcit-dirname |/ $ :storage-file config/site
           :examples $ []
           :schema $ :: 'Dynamic
-        |sync-clients! $ %{} :CodeEntry (:doc |)
+        |sync-clients! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn sync-clients! (reel)
               wss-each! $ fn (sid)
@@ -1239,7 +1294,7 @@
                       swap! *client-caches assoc sid new-store
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.server $ :require (app.schema :as schema)
             app.updater :refer $ updater
@@ -1254,29 +1309,29 @@
             calcit.std.time :refer $ set-interval
             calcit.std.date :refer $ get-time! extract-time format-time get-timestamp
             calcit.std.path :refer $ join-path
-    |app.style $ %{} :FileEntry
+    |app.style $ %{} 'FileEntry
       :defs $ {}
-        |button $ %{} :CodeEntry (:doc |)
+        |button $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def button $ merge ui/button
               {} $ :background-color :white
           :examples $ []
           :schema $ :: 'Dynamic
-        |link $ %{} :CodeEntry (:doc |)
+        |link $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def link $ {} (:text-decoration :underline) (:cursor :pointer)
               :color $ hsl 240 80 80
               :font-family ui/font-fancy
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.style $ :require
             [] respo-ui.core :refer $ [] hsl
             [] respo-ui.core :as ui
-    |app.twig.container $ %{} :FileEntry
+    |app.twig.container $ %{} 'FileEntry
       :defs $ {}
-        |twig-container $ %{} :CodeEntry (:doc |)
+        |twig-container $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn twig-container (db session records)
               let
@@ -1305,7 +1360,7 @@
                   {}
           :examples $ []
           :schema $ :: 'Dynamic
-        |twig-members $ %{} :CodeEntry (:doc |)
+        |twig-members $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn twig-members (sessions users)
               -> sessions $ .map-kv
@@ -1314,7 +1369,7 @@
                     [] (:user-id session) :name
           :examples $ []
           :schema $ :: 'Dynamic
-        |twig-notes-by-month $ %{} :CodeEntry (:doc |)
+        |twig-notes-by-month $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn twig-notes-by-month (data notes)
               let
@@ -1330,7 +1385,7 @@
                         = month $ :month time
           :examples $ []
           :schema $ :: 'Dynamic
-        |twig-tasks-by-week $ %{} :CodeEntry (:doc |)
+        |twig-tasks-by-week $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn twig-tasks-by-week (data tasks)
               let
@@ -1349,32 +1404,32 @@
                         &< t $ get-timestamp end-time
           :examples $ []
           :schema $ :: 'Dynamic
-        |week-millis $ %{} :CodeEntry (:doc |)
+        |week-millis $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def week-millis $ * 7 24 3600 1000
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.twig.container $ :require
             [] app.twig.user :refer $ [] twig-user
             calcit.std.rand :refer $ rand-hex-color!
             calcit.std.date :refer $ Date extract-time get-time! from-ywd from-ymd parse-time format-time get-timestamp
-    |app.twig.user $ %{} :FileEntry
+    |app.twig.user $ %{} 'FileEntry
       :defs $ {}
-        |twig-user $ %{} :CodeEntry (:doc |)
+        |twig-user $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn twig-user (user)
               -> user (dissoc :password) (dissoc :tasks)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.twig.user $ :require
             [] recollect.twig :refer $ [] deftwig
-    |app.updater $ %{} :FileEntry
+    |app.updater $ %{} 'FileEntry
       :defs $ {}
-        |updater $ %{} :CodeEntry (:doc |)
+        |updater $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn updater (db op sid op-id op-time)
               tag-match op
@@ -1399,22 +1454,22 @@
                 _ $ do (eprintln "|Unknown op:" op) db
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.updater $ :require ([] app.updater.session :as session) ([] app.updater.user :as user) ([] app.updater.router :as router) ([] app.updater.misc :as misc) ([] app.updater.task :as task) ([] app.updater.note :as note) ([] app.schema :as schema)
             [] respo-message.updater :refer $ [] update-messages
-    |app.updater.misc $ %{} :FileEntry
+    |app.updater.misc $ %{} 'FileEntry
       :defs $ {}
-        |set-today $ %{} :CodeEntry (:doc |)
+        |set-today $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn set-today (db op-data sid op-id op-time) (assoc db :today op-data)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.updater.misc)
-    |app.updater.note $ %{} :FileEntry
+    |app.updater.note $ %{} 'FileEntry
       :defs $ {}
-        |add-note $ %{} :CodeEntry (:doc |)
+        |add-note $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn add-note (db op-data sid op-id op-time)
               let
@@ -1425,7 +1480,7 @@
                 assoc-in db ([] :users user-id :notes op-id) new-note
           :examples $ []
           :schema $ :: 'Dynamic
-        |edit-note $ %{} :CodeEntry (:doc |)
+        |edit-note $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn edit-note (db op-data sid op-id op-time)
               let
@@ -1437,7 +1492,7 @@
                   fn (note) (assoc note :text text)
           :examples $ []
           :schema $ :: 'Dynamic
-        |remove-note $ %{} :CodeEntry (:doc |)
+        |remove-note $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn remove-note (db op-data sid op-id op-time)
               let
@@ -1447,35 +1502,35 @@
                   fn (notes) (dissoc notes op-data)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.updater.note $ :require ([] app.schema :as schema)
-    |app.updater.router $ %{} :FileEntry
+    |app.updater.router $ %{} 'FileEntry
       :defs $ {}
-        |change $ %{} :CodeEntry (:doc |)
+        |change $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn change (db op-data sid op-id op-time)
               assoc-in db ([] :sessions sid :router) op-data
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.updater.router)
-    |app.updater.session $ %{} :FileEntry
+    |app.updater.session $ %{} 'FileEntry
       :defs $ {}
-        |connect $ %{} :CodeEntry (:doc |)
+        |connect $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn connect (db sid op-id op-time)
               assoc-in db ([] :sessions sid)
                 merge schema/session $ {} (:id sid)
           :examples $ []
           :schema $ :: 'Dynamic
-        |disconnect $ %{} :CodeEntry (:doc |)
+        |disconnect $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn disconnect (db sid op-id op-time)
               update db :sessions $ fn (session) (dissoc session sid)
           :examples $ []
           :schema $ :: 'Dynamic
-        |remove-message $ %{} :CodeEntry (:doc |)
+        |remove-message $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn remove-message (db op-data sid op-id op-time)
               update-in db ([] :sessions sid :messages)
@@ -1483,12 +1538,12 @@
                   dissoc messages $ :id op-data
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.updater.session $ :require ([] app.schema :as schema)
-    |app.updater.task $ %{} :FileEntry
+    |app.updater.task $ %{} 'FileEntry
       :defs $ {}
-        |create-working $ %{} :CodeEntry (:doc |)
+        |create-working $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn create-working (db op-data sid op-id op-time)
               let
@@ -1497,7 +1552,7 @@
                   merge schema/task $ {} (:id op-id) (:text op-data) (:created-time op-time)
           :examples $ []
           :schema $ :: 'Dynamic
-        |finish-working $ %{} :CodeEntry (:doc |)
+        |finish-working $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn finish-working (db op-data sid op-id op-time)
               let
@@ -1513,7 +1568,7 @@
                         , tasks
           :examples $ []
           :schema $ :: 'Dynamic
-        |pend $ %{} :CodeEntry (:doc |)
+        |pend $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn pend (db op-data sid op-id op-time)
               let
@@ -1521,7 +1576,7 @@
                 update-in db ([] :users user-id :tasks :working op-data :pending?) not
           :examples $ []
           :schema $ :: 'Dynamic
-        |put-back $ %{} :CodeEntry (:doc |)
+        |put-back $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn put-back (db op-data sid op-id op-time)
               let
@@ -1537,7 +1592,7 @@
                         , tasks
           :examples $ []
           :schema $ :: 'Dynamic
-        |remove-working $ %{} :CodeEntry (:doc |)
+        |remove-working $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn remove-working (db op-data sid op-id op-time)
               let
@@ -1546,7 +1601,7 @@
                   fn (tasks) (dissoc tasks op-data)
           :examples $ []
           :schema $ :: 'Dynamic
-        |touch-working $ %{} :CodeEntry (:doc |)
+        |touch-working $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn touch-working (db op-data sid op-id op-time)
               let
@@ -1556,7 +1611,7 @@
                     if (some? task) (assoc task :touched-time op-time) nil
           :examples $ []
           :schema $ :: 'Dynamic
-        |update-working $ %{} :CodeEntry (:doc |)
+        |update-working $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn update-working (db op-data sid op-id op-time)
               let
@@ -1569,12 +1624,12 @@
                       , nil
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.updater.task $ :require ([] app.schema :as schema)
-    |app.updater.user $ %{} :FileEntry
+    |app.updater.user $ %{} 'FileEntry
       :defs $ {}
-        |log-in $ %{} :CodeEntry (:doc |)
+        |log-in $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn log-in (db op-data sid op-id op-time)
               let-sugar
@@ -1597,13 +1652,13 @@
                           :text $ str "|No user named: " username
           :examples $ []
           :schema $ :: 'Dynamic
-        |log-out $ %{} :CodeEntry (:doc |)
+        |log-out $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn log-out (db sid op-id op-time)
               assoc-in db ([] :sessions sid :user-id) nil
           :examples $ []
           :schema $ :: 'Dynamic
-        |sign-up $ %{} :CodeEntry (:doc |)
+        |sign-up $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn sign-up (db op-data sid op-id op-time)
               let-sugar
@@ -1626,7 +1681,7 @@
                         :avatar nil
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.updater.user $ :require
             [] cumulo-util.core :refer $ [] find-first

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,38 +1,46 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |app) (:version |0.1.0)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |app)
   :entries $ {}
     :default $ {} (:description "||Browser client bundle") (:init-fn 'app.client/main!) (:mode :js) (:reload-fn 'app.client/reload!)
-      :modules $ [] |lilac/ |recollect/ |memof/ |respo-ui.calcit/ |ws-edn.calcit/ |cumulo-util.calcit/ |respo-message.calcit/ |cumulo-reel.calcit/ |respo-feather.calcit/ |alerts.calcit/ |respo-markdown.calcit/ |respo.calcit/ |js-ffi/
+      :feature-policy $ {}
+      :modules $ [] |recollect/ |respo-ui.calcit/ |ws-edn.calcit/ |cumulo-util.calcit/ |respo-message.calcit/ |cumulo-reel.calcit/ |respo-feather.calcit/ |alerts.calcit/ |respo-markdown.calcit/ |respo.calcit/ |js-ffi/
       :type-slots $ {}
     :server $ {} (:description "||Realtime server") (:init-fn 'app.server/main!) (:mode :native) (:reload-fn 'app.server/reload!)
-      :modules $ [] |lilac/ |recollect/ |memof/ |cumulo-util.calcit/ |cumulo-reel.calcit/ |calcit.std/ |calcit-wss/
+      :feature-policy $ {}
+      :modules $ [] |recollect/ |cumulo-util.calcit/ |cumulo-reel.calcit/ |calcit.std/ |calcit-wss/
       :type-slots $ {}
   :files $ {}
-    |app.client $ %{} :FileEntry
+    |app.client $ %{} 'FileEntry
       :defs $ {}
-        |*states $ %{} :CodeEntry (:doc |)
+        |*states $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defatom *states $ {}
               :states $ {}
                 :cursor $ []
           :examples $ []
           :schema $ :: 'Dynamic
-        |*store $ %{} :CodeEntry (:doc |)
+        |*store $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defatom *store $ :: :initial
           :examples $ []
           :schema $ :: 'Dynamic
-        |connect! $ %{} :CodeEntry (:doc |)
+        |connect! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn connect! () $ let
-                location $ unsafe-coerce js/location JsObject
-                url-obj $ unsafe-coerce (url-parse (.-href location) true) JsObject
-                query $ unsafe-coerce (.-query url-obj) JsObject
-                raw-host $ .-host query
-                raw-port $ .-port query
-                raw-hostname $ .-hostname location
-                host $ if (js-present? raw-host) (unsafe-coerce raw-host String) raw-hostname
-                port $ if (js-present? raw-port) (unsafe-coerce raw-port String) (:port config/site)
+                url-obj $ unsafe-coerce (url-parse js/location.href true) 'JsObject
+                query $ unsafe-coerce (.-query url-obj) 'JsObject
+                host $ unsafe-coerce
+                  if
+                    js-present? $ .-host query
+                    .-host query
+                    unsafe-coerce js/location.hostname 'String
+                  , 'String
+                port $ unsafe-coerce
+                  if
+                    js-present? $ .-port query
+                    .-port query
+                    :port config/site
+                  , 'String
               ws-connect!
                 if config/dev? (str |ws:// host |: port) |wss://timegrass.topix.im/ws
                 {}
@@ -43,7 +51,7 @@
                   :on-data on-server-data
           :examples $ []
           :schema $ :: 'Dynamic
-        |dispatch! $ %{} :CodeEntry (:doc |)
+        |dispatch! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn dispatch! (op)
               when
@@ -56,7 +64,7 @@
                 _ $ ws-send! op
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (.!extend dayjs week-of-year)
               println "|Running mode:" $ if config/dev? |dev |release
@@ -78,12 +86,12 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |mount-target $ %{} :CodeEntry (:doc |)
+        |mount-target $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def mount-target $ js/document.querySelector |.app
           :examples $ []
           :schema $ :: 'Dynamic
-        |on-server-data $ %{} :CodeEntry (:doc |)
+        |on-server-data $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn on-server-data (data)
               tag-match data
@@ -94,7 +102,7 @@
                 (:effect/pong) :ok
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ if
               or $ some? client-errors
@@ -105,25 +113,25 @@
                 println "|Code updated."
           :examples $ []
           :schema $ :: 'Dynamic
-        |render-app! $ %{} :CodeEntry (:doc |)
+        |render-app! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn render-app! () $ render! mount-target
-              comp-container (:states @*states) @*store
+              comp-container (&map:get @*states :states) @*store
               , dispatch!
           :examples $ []
           :schema $ :: 'Dynamic
-        |simulate-login! $ %{} :CodeEntry (:doc |)
+        |simulate-login! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn simulate-login! () $ let
                 raw $ js/localStorage.getItem (:storage-key config/site)
               if (js-present? raw)
                 do (println "|Found storage.")
                   dispatch! $ :: :user/log-in
-                    parse-cirru-edn $ unsafe-coerce raw String
+                    parse-cirru-edn $ unsafe-coerce raw 'String
                 do $ println "|Found no storage."
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.client $ :require
             respo.core :refer $ render! clear-cache! realize-ssr!
@@ -139,45 +147,43 @@
             |./calcit.build-errors :default client-errors
             |dayjs :default dayjs
             |dayjs/plugin/weekOfYear :default week-of-year
-    |app.comp.container $ %{} :FileEntry
+    |app.comp.container $ %{} 'FileEntry
       :defs $ {}
-        |comp-container $ %{} :CodeEntry (:doc |)
+        |comp-container $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn comp-container (states store)
               case-default store
                 let
-                    state $ :data states
-                    session $ :session store
-                    router $ :router store
-                    router-data $ :data router
+                    state $ &map:get states :data
+                    session $ &map:get store :session
+                    router $ &map:get store :router
+                    router-data $ &map:get router :data
                   div
                     {} $ :class-name css-container
-                    comp-navigation (:logged-in? store) (:count store) (:name router)
-                    if (:logged-in? store)
-                      case-default (:name router)
+                    comp-navigation (&map:get store :logged-in?) (&map:get store :count) (&map:get router :name)
+                    if (&map:get store :logged-in?)
+                      case-default (&map:get router :name)
                         <> $ str "|404 page:" router
-                        :home $ comp-overview (>> states :overview) (:today store)
+                        :home $ comp-overview (>> states :overview) (&map:get store :today)
                           get-in router $ [] :data :tasks
                         :history $ comp-history (>> states :history)
                           get-in router $ [] :data :week
                           get-in router $ [] :data :tasks
-                        :notes $ comp-notes-page (>> states :notes) (:data router)
+                        :notes $ comp-notes-page (>> states :notes) (&map:get router :data)
                           get-in session $ [] :router :data
-                        :profile $ comp-profile (:user store) (:data router)
+                        :profile $ comp-profile (&map:get store :user) (&map:get router :data)
                       comp-login $ >> states :login
-                    comp-status-color $ :color store
+                    comp-status-color $ &map:get store :color
                     when dev? $ comp-inspect |Store store
                       {} (:bottom 0) (:left 0) (:z-index 9999)
-                    comp-messages
-                      get-in store $ [] :session :messages
-                      {}
+                    comp-messages (&map:get session :messages) ({})
                       fn (info d!) (d! :session/remove-message info)
-                    when dev? $ comp-reel (:reel-length store) ({})
+                    when dev? $ comp-reel (&map:get store :reel-length) ({})
                 (:: :initial) (comp-offline :initial)
                 (:: :offline) (comp-offline :offline)
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-offline $ %{} :CodeEntry (:doc |)
+        |comp-offline $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-offline (state)
               div
@@ -199,39 +205,39 @@
                     {} (:font-family ui/font-fancy) (:font-weight 100) (:font-size 24)
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-status-color $ %{} :CodeEntry (:doc |)
+        |comp-status-color $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-status-color (color)
               div $ {} (:class-name css-status-color)
                 :style $ {} (:background-color color)
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-container $ %{} :CodeEntry (:doc |)
+        |css-container $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-container $ {}
               |$0 $ merge ui/global ui/fullscreen ui/column
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-offline $ %{} :CodeEntry (:doc |)
+        |css-offline $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-offline $ {}
               |$0 $ merge ui/global ui/fullscreen ui/column-dispersive
                 {} $ :background-color (:theme config/site)
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-status-color $ %{} :CodeEntry (:doc |)
+        |css-status-color $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-status-color $ {}
               |$0 $ {} (:width 16) (:height 16) (:position :absolute) (:bottom 16) (:right 8) (:border-radius |8px) (:opacity 0.8) (:transition-duration |200ms) (:opacity 0.5)
               |$0:hover $ {} (:opacity 0.7)
           :examples $ []
           :schema $ :: 'Dynamic
-        |style-body $ %{} :CodeEntry (:doc |)
+        |style-body $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def style-body $ {} (:padding "|8px 16px")
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.comp.container $ :require
             hsl.core :refer $ hsl
@@ -252,26 +258,29 @@
             app.config :as config
             app.comp.history :refer $ comp-history
             app.comp.notes-page :refer $ comp-notes-page
-    |app.comp.history $ %{} :FileEntry
+    |app.comp.history $ %{} 'FileEntry
       :defs $ {}
-        |comp-done-task $ %{} :CodeEntry (:doc |)
+        |comp-done-task $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-done-task (states task)
               let
-                  cursor $ :cursor states
-                  state $ or (:data states)
+                  cursor $ &map:get states :cursor
+                  state $ or (&map:get states :data)
                     {} $ :show-menu? false
+                  finished-day $ unsafe-coerce
+                    dayjs $ &map:get task :finished-time
+                    , 'JsObject
                 div
                   {} (:class-name css-done-task)
                     :style $ merge
                       {} $ :padding "|4px 8px"
-                      if (:show-menu? state)
+                      if (&map:get state :show-menu?)
                         {} $ :background-color (hsl 0 0 94)
                         {}
                     :on-click $ fn (e d!)
                       d! cursor $ assoc state :show-menu? true
                   <>
-                    -> (:finished-time task) dayjs $ .!format |HH:mm
+                    unsafe-coerce (.!format finished-day |HH:mm) 'String
                     {} (:min-width 32)
                       :color $ hsl 0 0 80
                       :font-size 12
@@ -280,27 +289,27 @@
                   span
                     {} $ :style
                       merge ui/flex $ {} (:line-height |24px)
-                    <> $ :text task
+                    <> $ &map:get task :text
                   comp-modal-menu
                     {} (:title |Operations)
                       :style $ {} (:width 320)
                       :items $ [] (:: :item :put-back "|Put back")
-                    :show-menu? state
+                    &map:get state :show-menu?
                     fn (d!)
                       d! cursor $ assoc state :show-menu? false
                     fn (item d!)
                       d! cursor $ assoc state :show-menu? false
                       when
-                        = :put-back $ nth item 1
-                        d! :task/put-back $ :id task
+                        = :put-back $ option:unwrap-or (nth item 1) nil
+                        d! :task/put-back $ &map:get task :id
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-history $ %{} :CodeEntry (:doc |)
+        |comp-history $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-history (states data finished-tasks)
               let
-                  year $ :year data
-                  week $ :week data
+                  year $ &map:get data :year
+                  week $ &map:get data :week
                 div
                   {} (:class-name css/flex)
                     :style $ {} (:padding "|16px 16px") (:overflow :auto)
@@ -325,10 +334,14 @@
                                   change-year? $ <= week 1
                                   y $ if change-year? (dec year) year
                                   w $ if change-year? 53 (dec week)
-                                  d $ -> (dayjs) (.!year y) (.!week w)
+                                  base-day $ unsafe-coerce (dayjs) 'JsObject
+                                  year-day $ unsafe-coerce (.!year base-day y) 'JsObject
+                                  d $ unsafe-coerce (.!week year-day w) 'JsObject
+                                  start-day $ unsafe-coerce (.!startOf d |week) 'JsObject
+                                  end-day $ unsafe-coerce (.!endOf d |week) 'JsObject
                                 {} (:year y) (:week w)
-                                  :start $ .!format (.!startOf d |week)
-                                  :end $ .!format (.!endOf d |week)
+                                  :start $ unsafe-coerce (.!format start-day |week) 'String
+                                  :end $ unsafe-coerce (.!format end-day |week) 'String
                         =< 8 nil
                         comp-icon :arrow-right
                           {} (:font-size 16)
@@ -340,10 +353,14 @@
                                   change-year? $ >= week 53
                                   y $ if change-year? (inc year) year
                                   w $ if change-year? 1 (inc week)
-                                  d $ -> (dayjs) (.!year y) (.!week w)
+                                  base-day $ unsafe-coerce (dayjs) 'JsObject
+                                  year-day $ unsafe-coerce (.!year base-day y) 'JsObject
+                                  d $ unsafe-coerce (.!week year-day w) 'JsObject
+                                  start-day $ unsafe-coerce (.!startOf d |week) 'JsObject
+                                  end-day $ unsafe-coerce (.!endOf d |week) 'JsObject
                                 {} (:year y) (:week w)
-                                  :start $ .!format (.!startOf d |week)
-                                  :end $ .!format (.!endOf d |week)
+                                  :start $ unsafe-coerce (.!format start-day |week) 'String
+                                  :end $ unsafe-coerce (.!format end-day |week) 'String
                     if (empty? finished-tasks)
                       div
                         {} (:class-name css/center)
@@ -353,39 +370,45 @@
                       let
                           grouped-tasks $ -> finished-tasks (.to-list) (.map last)
                             group-by $ fn (task)
-                              .!format
-                                dayjs $ :finished-time task
-                                , |YYYY-MM-DD
+                              unsafe-coerce
+                                .!format
+                                  unsafe-coerce
+                                    dayjs $ &map:get task :finished-time
+                                    , 'JsObject
+                                  , |YYYY-MM-DD
+                                , 'String
                         list-> ({})
                           -> grouped-tasks (.to-list)
                             .sort $ fn (x y)
-                              &compare (first y) (first x)
+                              &compare
+                                option:unwrap-or (first y) |
+                                option:unwrap-or (first x) |
                             .map-pair $ fn (date-string task-list)
                               [] date-string $ div
                                 {} (:class-name css/column)
                                   :style $ {} (:margin-top 16)
                                 let
-                                    the-day $ dayjs date-string
+                                    the-day $ unsafe-coerce (dayjs date-string) 'JsObject
                                   div
                                     {} $ :class-name css/row-parted
                                     span
                                       {} $ :class-name css/font-fancy
-                                      <> $ .!format the-day |ddd
+                                      <> $ unsafe-coerce (.!format the-day |ddd) 'String
                                       =< 12 nil
-                                      <> $ .!format the-day |MM-DD
+                                      <> $ unsafe-coerce (.!format the-day |MM-DD) 'String
                                 =< nil 4
                                 list-> ({})
                                   -> task-list
                                     .sort-by $ fn (task)
-                                      negate $ :finished-time task
+                                      negate $ &map:get task :finished-time
                                     .map $ fn (task)
-                                      [] (:id task)
+                                      [] (&map:get task :id)
                                         comp-done-task
-                                          >> states $ :id task
+                                          >> states $ &map:get task :id
                                           , task
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-done-task $ %{} :CodeEntry (:doc |)
+        |css-done-task $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-done-task $ {}
               |$0 $ {} (:transition-duration |200ms)
@@ -393,7 +416,7 @@
                 :background-color $ hsl 0 0 80 0.2
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.comp.history $ :require
             respo-ui.core :refer $ hsl
@@ -406,14 +429,14 @@
             respo-alerts.core :refer $ comp-modal-menu
             |dayjs :default dayjs
             feather.core :refer $ comp-icon
-    |app.comp.login $ %{} :FileEntry
+    |app.comp.login $ %{} 'FileEntry
       :defs $ {}
-        |comp-login $ %{} :CodeEntry (:doc |)
+        |comp-login $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-login (states)
               let
-                  cursor $ :cursor states
-                  state $ or (:data states) initial-state
+                  cursor $ &map:get states :cursor
+                  state $ or (&map:get states :data) initial-state
                 div
                   {} $ :style (merge ui/flex ui/center)
                   div ({})
@@ -421,38 +444,38 @@
                       {} $ :style ({})
                       div ({})
                         input $ {} (:placeholder |Username)
-                          :value $ :username state
+                          :value $ &map:get state :username
                           :style ui/input
                           :on-input $ fn (e d!)
                             d! cursor $ assoc state :username
-                              str $ :value e
+                              str $ &map:get e :value
                       =< nil 8
                       div ({})
                         input $ {} (:placeholder |Password)
-                          :value $ :password state
+                          :value $ &map:get state :password
                           :style ui/input
                           :on-input $ fn (e d!)
                             d! cursor $ assoc state :password
-                              str $ :value e
+                              str $ &map:get e :value
                     =< nil 8
                     div
                       {} $ :style
                         {} $ :text-align :right
                       span $ {} (:inner-text "|Sign up")
                         :style $ merge style/link
-                        :on-click $ on-submit (:username state) (:password state) true
+                        :on-click $ on-submit (&map:get state :username) (&map:get state :password) true
                       =< 8 nil
                       span $ {} (:inner-text "|Log in")
                         :style $ merge style/link
-                        :on-click $ on-submit (:username state) (:password state) false
+                        :on-click $ on-submit (&map:get state :username) (&map:get state :password) false
           :examples $ []
           :schema $ :: 'Dynamic
-        |initial-state $ %{} :CodeEntry (:doc |)
+        |initial-state $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def initial-state $ {} (:username |) (:password |)
           :examples $ []
           :schema $ :: 'Dynamic
-        |on-submit $ %{} :CodeEntry (:doc |)
+        |on-submit $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn on-submit (username password signup?)
               fn (e dispatch!)
@@ -461,7 +484,7 @@
                   format-cirru-edn $ [] username password
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.comp.login $ :require
             [] respo.core :refer $ [] defcomp <> div input button span
@@ -471,9 +494,9 @@
             [] app.schema :as schema
             [] app.style :as style
             [] app.config :as config
-    |app.comp.navigation $ %{} :FileEntry
+    |app.comp.navigation $ %{} 'FileEntry
       :defs $ {}
-        |comp-navigation $ %{} :CodeEntry (:doc |)
+        |comp-navigation $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-navigation (logged-in? count-members page)
               div
@@ -490,20 +513,22 @@
                     render-entry |Finished
                       fn () $ {} (:name :history)
                         :data $ let
-                            now $ dayjs
+                            now $ unsafe-coerce (dayjs) 'JsObject
                             month $ .!month now
-                            week-date now
+                            week-date $ unsafe-coerce now 'JsObject
+                            start-day $ unsafe-coerce (.!startOf week-date |week) 'JsObject
+                            end-day $ unsafe-coerce (.!endOf week-date |week) 'JsObject
                           {}
                             :year $ .!year now
                             :week $ .!week week-date
-                            :start $ .!format (.!startOf week-date |week)
-                            :end $ .!format (.!endOf week-date |week)
+                            :start $ unsafe-coerce (.!format start-day |week) 'String
+                            :end $ unsafe-coerce (.!format end-day |week) 'String
                       = page :history
                     =< 16 nil
                     render-entry |Notes
                       fn () $ {} (:name :notes)
                         :data $ let
-                            now $ dayjs
+                            now $ unsafe-coerce (dayjs) 'JsObject
                           {}
                             :year $ .!year now
                             :month $ .!month now
@@ -519,14 +544,14 @@
                     <> count-members
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-entry $ %{} :CodeEntry (:doc |)
+        |css-entry $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-entry $ {}
               |$0 $ {} (:opacity 0.6) (:user-select :none) (:transition-duration |200ms)
               |$0:hover $ {} (:opacity 0.8)
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-navbar $ %{} :CodeEntry (:doc |)
+        |css-navbar $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-navbar $ {}
               |$0 $ merge ui/row-center
@@ -537,7 +562,7 @@
                   :color :white
           :examples $ []
           :schema $ :: 'Dynamic
-        |render-entry $ %{} :CodeEntry (:doc |)
+        |render-entry $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn render-entry (title get-route highlighted?)
               div
@@ -551,7 +576,7 @@
                 <> title nil
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.comp.navigation $ :require
             respo-ui.core :refer $ hsl
@@ -563,17 +588,20 @@
             app.config :as config
             respo-alerts.core :refer $ comp-prompt
             |dayjs :default dayjs
-    |app.comp.notes-page $ %{} :FileEntry
+    |app.comp.notes-page $ %{} 'FileEntry
       :defs $ {}
-        |comp-note $ %{} :CodeEntry (:doc |)
+        |comp-note $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-note (states note)
               let
                   edit-plugin $ use-prompt (>> states :edit)
                     {} (:text "|Update note:") (:multiline? true)
-                      :initial $ :text note
+                      :initial $ &map:get note :text
                   remove-plugin $ use-confirm (>> states :remove)
                     {} $ :text "|Sure to delete note?"
+                  note-day $ unsafe-coerce
+                    dayjs $ &map:get note :time
+                    , 'JsObject
                 div
                   {}
                     :class-name $ str-spaced css/column css-note
@@ -583,7 +611,7 @@
                   div
                     {} $ :class-name css/row-parted
                     <>
-                      -> (:time note) dayjs $ .!format |HH:mm
+                      unsafe-coerce (.!format note-day |HH:mm) 'String
                       {} (:font-family ui/font-fancy)
                         :color $ hsl 0 0 70
                         :font-size 12
@@ -595,25 +623,25 @@
                         fn (e d!)
                           .show edit-plugin d! $ fn (result)
                             d! :note/edit $ {}
-                              :id $ :id note
+                              :id $ &map:get note :id
                               :text result
                       =< 8 nil
                       comp-icon :delete
                         &{} :font-size 16 :cursor :pointer :color $ hsl 10 80 60
                         fn (e d!)
                           .show remove-plugin d! $ fn ()
-                            d! :note/remove $ :id note
-                  <> $ :text note
+                            d! :note/remove $ &map:get note :id
+                  <> $ &map:get note :text
                   .render edit-plugin
                   .render remove-plugin
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-notes-page $ %{} :CodeEntry (:doc |)
+        |comp-notes-page $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-notes-page (states notes info)
               let
-                  year $ :year info
-                  month $ :month info
+                  year $ &map:get info :year
+                  month $ &map:get info :month
                   add-plugin $ use-prompt (>> states :add)
                     {} (:text "|Add note about today's work:") (:multiline? true)
                 div
@@ -677,12 +705,19 @@
                       let
                           grouped-notes $ -> notes (.to-list)
                             .group-by $ fn (pair)
-                              ->
-                                :time $ last pair
-                                , dayjs $ .!format |MM-DD
+                              let
+                                  pair-value $ unsafe-coerce (nth pair 1) 'Dynamic
+                                  note-time $ &map:get pair-value :time
+                                unsafe-coerce
+                                  .!format
+                                    unsafe-coerce (dayjs note-time) 'JsObject
+                                    , |MM-DD
+                                  , 'String
                             .to-list
                             .sort $ fn (x y)
-                              &compare (first y) (first x)
+                              &compare
+                                option:unwrap-or (first y) |
+                                option:unwrap-or (first x) |
                         list-> ({})
                           -> grouped-notes (.to-list)
                             .map-pair $ fn (date notes-in-day)
@@ -692,21 +727,29 @@
                                 div
                                   {} (:class-name css/font-fancy)
                                     :style $ {} (:font-size 14) (:font-weight 500)
-                                  <> $ -> (str year |- date) dayjs (.!format |ddd)
+                                  <> $ unsafe-coerce
+                                    .!format
+                                      unsafe-coerce
+                                        dayjs $ str year |- date
+                                        , 'JsObject
+                                      , |ddd
+                                    , 'String
                                   =< 12 nil
                                   <> $ str date
                                 list->
                                   {} $ :class-name css/column
                                   -> notes-in-day
                                     .sort-by $ fn (pair)
-                                      negate $ :time (last pair)
+                                      let
+                                          note-value $ unsafe-coerce (nth pair 1) 'Dynamic
+                                        negate $ &map:get note-value :time
                                     .map-pair $ fn (k note)
                                       [] k $ comp-note (>> states k) note
                     =< nil 160
                   .render add-plugin
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-note $ %{} :CodeEntry (:doc |)
+        |css-note $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-note $ {}
               |$0 $ {} (:transition-duration |200ms)
@@ -714,7 +757,7 @@
                 :background-color $ hsl 0 0 80 0.2
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.comp.notes-page $ :require
             respo-ui.core :refer $ hsl
@@ -728,9 +771,16 @@
             respo-alerts.core :refer $ use-prompt use-confirm
             feather.core :refer $ comp-i comp-icon
             |dayjs :default dayjs
-    |app.comp.overview $ %{} :FileEntry
+    |app.comp.overview $ %{} 'FileEntry
       :defs $ {}
-        |comp-no-tasks $ %{} :CodeEntry (:doc |)
+        |comp-global-keydown $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defcomp comp-global-keydown (options on-event)
+              span $ {}
+                :on-keydown $ fn (e d!) (on-event e d!)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |comp-no-tasks $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-no-tasks () $ div
               {}
@@ -740,21 +790,22 @@
               <> "|No tasks"
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-overview $ %{} :CodeEntry (:doc |)
+        |comp-overview $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-overview (states today tasks)
               let
                   working-tasks $ -> tasks (.to-map)
                     filter $ fn (pair)
-                      not $ :pending? (last pair)
+                      not $ &map:get (last pair) :pending?
                   pending-tasks $ -> tasks (.to-map)
                     filter $ fn (pair)
-                      :pending? $ last pair
+                      &map:get (last pair) :pending?
                   create-plugin $ use-prompt (>> states :create)
                     {} $ :text "|Create new task:"
-                  cursor $ :cursor states
-                  state $ or (:data states)
+                  cursor $ &map:get states :cursor
+                  state $ or (&map:get states :data)
                     {} $ :show-later? false
+                  today-day $ unsafe-coerce (dayjs today) 'JsObject
                 div
                   {} (:class-name css/expand)
                     :style $ {} (:padding 16)
@@ -770,19 +821,17 @@
                       comp-global-keydown ({})
                         fn (e d!)
                           if
-                            and (:meta? e)
-                              = |i $ :key e
+                            and (&map:get e :meta?)
+                              = |i $ &map:get e :key
                             .show create-plugin d! $ fn (result) (d! :task/create-working result)
                       div
                         {}
                           :class-name $ str-spaced css/row-middle css/font-fancy
                           :style $ {}
                             :color $ hsl 0 0 60
-                        <> $ .!format (dayjs today) |ddd
+                        <> $ unsafe-coerce (.!format today-day |ddd) 'String
                         =< 8 nil
-                        <> $ str
-                          .!week $ dayjs today
-                          , "|th week"
+                        <> $ str (.!week today-day) "|th week"
                         =< 16 nil
                         <> today
                     if (empty? working-tasks) (comp-no-tasks)
@@ -791,26 +840,26 @@
                           .sort-by $ fn (pair)
                             let
                                 task $ last pair
-                              negate $ or (:touched-time task) (:created-time task)
+                              negate $ or (&map:get task :touched-time) (&map:get task :created-time)
                           .map-pair $ fn (k task)
                             [] k $ comp-task
-                              >> states $ :id task
+                              >> states $ &map:get task :id
                               , task :working
                     when
                       not $ empty? pending-tasks
                       div ({})
                         comp-title |Later nil $ fn (e d!)
                           d! cursor $ update state :show-later? not
-                        if (:show-later? state)
+                        if (&map:get state :show-later?)
                           list-> ({})
                             -> pending-tasks (.to-list)
                               .sort-by $ fn (pair)
                                 let
                                     task $ last pair
-                                  negate $ or (:touched-time task) (:created-time task)
+                                  negate $ or (&map:get task :touched-time) (&map:get task :created-time)
                               .map-pair $ fn (k task)
                                 [] k $ comp-task
-                                  >> states $ :id task
+                                  >> states $ &map:get task :id
                                   , task :pending
                           div
                             {}
@@ -823,16 +872,16 @@
                     .render create-plugin
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-task $ %{} :CodeEntry (:doc |)
+        |comp-task $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-task (states task mode)
               let
-                  cursor $ :cursor states
-                  state $ or (:data states)
+                  cursor $ &map:get states :cursor
+                  state $ or (&map:get states :data)
                     {} $ :menu? false
                   update-plugin $ use-prompt (>> states :drafter)
                     {} (:text "|Task content:")
-                      :initial $ :text task
+                      :initial $ &map:get task :text
                       :placeholder |task...
                       :button-text |Edit
                   delete-plugin $ use-confirm (>> states :delete)
@@ -840,18 +889,18 @@
                 div
                   {} (:class-name css-task-base)
                     :style $ merge
-                      if (:menu? state)
+                      if (&map:get state :menu?)
                         {} $ :background-color (hsl 0 0 94)
                         {}
                     :on-click $ fn (e d!)
                       d! cursor $ assoc state :menu? true
                     :on $ {}
                       :dragend $ fn (e d!)
-                        d! :task/touch-working $ :id task
+                        d! :task/touch-working $ &map:get task :id
                     :draggable true
                   div
                     {} $ :style ui/flex
-                    <> (:text task) ({})
+                    <> (&map:get task :text) ({})
                   comp-modal-menu
                     {} (:title |Operations)
                       :style $ {} (:width 320)
@@ -861,7 +910,7 @@
                         :: :item :copy |Copy
                         :: :item :edit |Edit
                         :: :item :remove |Remove
-                    :menu? state
+                    &map:get state :menu?
                     fn (d!)
                       d! cursor $ assoc state :menu? false
                     fn (item d!)
@@ -871,30 +920,30 @@
                         js/console.log item
                         case-default result (d! cursor new-state)
                           :done $ do
-                            d! :task/finish-working $ :id task
+                            d! :task/finish-working $ &map:get task :id
                             d! cursor new-state
                           :edit $ do (d! cursor new-state)
                             .show update-plugin d! $ fn (text)
                               d! :task/update-working $ {}
-                                :id $ :id task
+                                :id $ &map:get task :id
                                 :text text
                           :copy $ do
-                            copy! $ :text task
+                            copy! $ &map:get task :text
                             d! cursor new-state
                           :remove $ do (d! cursor new-state)
                             .show delete-plugin d! $ fn ()
-                              d! :task/remove-working $ :id task
+                            d! :task/remove-working $ &map:get task :id
                           :pend $ do
-                            d! :task/pend $ :id task
+                            d! :task/pend $ &map:get task :id
                             d! cursor new-state
                           :touch $ do
-                            d! :task/touch-working $ :id task
+                            d! :task/touch-working $ &map:get task :id
                             d! cursor new-state
                   .render update-plugin
                   .render delete-plugin
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-title $ %{} :CodeEntry (:doc |)
+        |comp-title $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-title (title child ? on-click)
               div
@@ -908,7 +957,7 @@
                 , child
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-task-base $ %{} :CodeEntry (:doc |)
+        |css-task-base $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-task-base $ {}
               |$0 $ {}
@@ -922,7 +971,7 @@
                 :background-color $ hsl 0 0 80 0.1
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-title $ %{} :CodeEntry (:doc |)
+        |css-title $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-title $ {}
               |$0 $ merge ui/row-middle
@@ -932,7 +981,7 @@
                   :font-weight 300
           :examples $ []
           :schema $ :: 'Dynamic
-        |effect-focus $ %{} :CodeEntry (:doc |)
+        |effect-focus $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defeffect effect-focus () (action el *local)
               case action
@@ -940,7 +989,7 @@
                 do
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.comp.overview $ :require
             respo-ui.core :refer $ hsl
@@ -956,10 +1005,9 @@
             feather.core :refer $ comp-i comp-icon
             |dayjs :default dayjs
             |copy-text-to-clipboard :default copy!
-            respo.comp.global-keydown :refer $ comp-global-keydown
-    |app.comp.profile $ %{} :FileEntry
+    |app.comp.profile $ %{} 'FileEntry
       :defs $ {}
-        |comp-profile $ %{} :CodeEntry (:doc |)
+        |comp-profile $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-profile (user members)
               div
@@ -971,7 +1019,7 @@
                   div
                     {} (:class-name css/font-fancy)
                       :style $ {} (:font-size 32) (:font-weight 100)
-                    <> $ str "|Hello! " (:name user)
+                    <> $ str "|Hello! " (&map:get user :name)
                   =< nil 16
                   div
                     {} $ :class-name css/row
@@ -1000,7 +1048,7 @@
                       <> "|Log out"
           :examples $ []
           :schema $ :: 'Dynamic
-        |css-member-label $ %{} :CodeEntry (:doc |)
+        |css-member-label $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle css-member-label $ {}
               |$0 $ {} (:padding "|0 8px")
@@ -1009,7 +1057,7 @@
                 :margin "|0 4px"
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.comp.profile $ :require
             respo-ui.core :refer $ hsl
@@ -1020,28 +1068,29 @@
             respo.css :refer $ defstyle
             respo.comp.space :refer $ =<
             app.config :as config
-    |app.config $ %{} :FileEntry
+    |app.config $ %{} 'FileEntry
       :defs $ {}
-        |dev? $ %{} :CodeEntry (:doc |)
+        |dev? $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            def dev? $ = |dev $ option:unwrap-or (get-env |mode) |release
+            def dev? $ = |dev
+              option:unwrap-or (get-env |mode) |release
           :examples $ []
           :schema $ :: 'Dynamic
-        |site $ %{} :CodeEntry (:doc |)
+        |site $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def site $ {} (:port 11009) (:title |Timegrass) (:icon |http://cdn.tiye.me/logo/timegrass.png) (:dev-ui |http://localhost:8100/main.css) (:release-ui |http://cdn.tiye.me/favored-fonts/main.css) (:cdn-url |http://cdn.tiye.me/timegrass/) (:theme |#51C766) (:storage-key |timegrass) (:storage-file |storage.cirru)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.config)
-    |app.schema $ %{} :FileEntry
+    |app.schema $ %{} 'FileEntry
       :defs $ {}
-        |complain $ %{} :CodeEntry (:doc |)
+        |complain $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def complain $ {} (:id nil) (:text |) (:time nil)
           :examples $ []
           :schema $ :: 'Dynamic
-        |database $ %{} :CodeEntry (:doc |)
+        |database $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def database $ {}
               :sessions $ do session ({})
@@ -1049,36 +1098,36 @@
               :today |2018-08-07
           :examples $ []
           :schema $ :: 'Dynamic
-        |note $ %{} :CodeEntry (:doc |)
+        |note $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def note $ {} (:id nil) (:time nil) (:updated-time nil) (:text nil)
           :examples $ []
           :schema $ :: 'Dynamic
-        |notification $ %{} :CodeEntry (:doc |)
+        |notification $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def notification $ {} (:id nil) (:kind nil) (:text nil)
           :examples $ []
           :schema $ :: 'Dynamic
-        |router $ %{} :CodeEntry (:doc |)
+        |router $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def router $ {} (:name nil) (:title nil)
               :data $ {}
               :router nil
           :examples $ []
           :schema $ :: 'Dynamic
-        |session $ %{} :CodeEntry (:doc |)
+        |session $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def session $ {} (:user-id nil) (:id nil) (:nickname nil)
               :router $ {} (:name :home) (:data nil) (:router nil)
               :messages $ {}
           :examples $ []
           :schema $ :: 'Dynamic
-        |task $ %{} :CodeEntry (:doc |)
+        |task $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def task $ {} (:id nil) (:text |) (:detail |) (:pending? false) (:created-time nil) (:touched-time nil) (:finished-time nil) (:archived-time nil)
           :examples $ []
           :schema $ :: 'Dynamic
-        |user $ %{} :CodeEntry (:doc |)
+        |user $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def user $ {} (:name nil) (:id nil) (:nickname nil) (:avatar nil) (:password nil)
               :tasks $ {}
@@ -1088,16 +1137,16 @@
               :notes $ do note ({})
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.schema)
-    |app.server $ %{} :FileEntry
+    |app.server $ %{} 'FileEntry
       :defs $ {}
-        |*client-caches $ %{} :CodeEntry (:doc |)
+        |*client-caches $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defatom *client-caches $ {}
           :examples $ []
           :schema $ :: 'Dynamic
-        |*initial-db $ %{} :CodeEntry (:doc |)
+        |*initial-db $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defatom *initial-db $ if
               path-exists? $ w-log storage-file
@@ -1106,17 +1155,17 @@
               do (println "|Found no data") schema/database
           :examples $ []
           :schema $ :: 'Dynamic
-        |*reader-reel $ %{} :CodeEntry (:doc |)
+        |*reader-reel $ %{} 'CodeEntry (:doc |)
           :code $ quote (defatom *reader-reel @*reel)
           :examples $ []
           :schema $ :: 'Dynamic
-        |*reel $ %{} :CodeEntry (:doc |)
+        |*reel $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defatom *reel $ merge reel-schema
               {} (:base @*initial-db) (:db @*initial-db)
           :examples $ []
           :schema $ :: 'Dynamic
-        |dispatch! $ %{} :CodeEntry (:doc |)
+        |dispatch! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn dispatch! (op sid)
               let
@@ -1130,7 +1179,7 @@
                   _ $ reset! *reel (reel-reducer @*reel updater op sid op-id op-time config/dev?)
           :examples $ []
           :schema $ :: 'Dynamic
-        |get-backup-path! $ %{} :CodeEntry (:doc |)
+        |get-backup-path! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn get-backup-path! () $ let
                 now $ extract-time (get-time!)
@@ -1139,7 +1188,7 @@
                 str (:day now) |-snapshot.cirru
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! ()
               println "|Running mode:" $ if config/dev? |dev |release
@@ -1155,12 +1204,12 @@
               set-interval 60000 $ fn () (set-today!)
           :examples $ []
           :schema $ :: 'Dynamic
-        |on-exit! $ %{} :CodeEntry (:doc |)
+        |on-exit! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn on-exit! () (persist-db!) (; println "|exit code is...") (quit! 0)
           :examples $ []
           :schema $ :: 'Dynamic
-        |persist-db! $ %{} :CodeEntry (:doc |)
+        |persist-db! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn persist-db! () $ let
                 file-content $ format-cirru-edn
@@ -1171,7 +1220,7 @@
               check-write-file! backup-path file-content
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () (println "|Code updated..")
               if (not config/dev?) (raise "|reloading only happens in dev mode")
@@ -1180,7 +1229,7 @@
               sync-clients! @*reader-reel
           :examples $ []
           :schema $ :: 'Dynamic
-        |render-loop! $ %{} :CodeEntry (:doc |)
+        |render-loop! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn render-loop! () $ when
               not $ identical? @*reader-reel @*reel
@@ -1188,7 +1237,7 @@
               sync-clients! @*reader-reel
           :examples $ []
           :schema $ :: 'Dynamic
-        |run-server! $ %{} :CodeEntry (:doc |)
+        |run-server! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn run-server! (port)
               wss-serve! (&{} :port port)
@@ -1208,7 +1257,7 @@
                     _ $ println "|unknown data:" data
           :examples $ []
           :schema $ :: 'Dynamic
-        |set-today! $ %{} :CodeEntry (:doc |)
+        |set-today! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn set-today! () $ let
                 today $ wo-log
@@ -1218,14 +1267,14 @@
                 dispatch! (:: :today today) |system
           :examples $ []
           :schema $ :: 'Dynamic
-        |storage-file $ %{} :CodeEntry (:doc |)
+        |storage-file $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def storage-file $ if (empty? calcit-dirname)
               str calcit-dirname $ :storage-file config/site
               str calcit-dirname |/ $ :storage-file config/site
           :examples $ []
           :schema $ :: 'Dynamic
-        |sync-clients! $ %{} :CodeEntry (:doc |)
+        |sync-clients! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn sync-clients! (reel)
               wss-each! $ fn (sid)
@@ -1245,7 +1294,7 @@
                       swap! *client-caches assoc sid new-store
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.server $ :require (app.schema :as schema)
             app.updater :refer $ updater
@@ -1260,29 +1309,29 @@
             calcit.std.time :refer $ set-interval
             calcit.std.date :refer $ get-time! extract-time format-time get-timestamp
             calcit.std.path :refer $ join-path
-    |app.style $ %{} :FileEntry
+    |app.style $ %{} 'FileEntry
       :defs $ {}
-        |button $ %{} :CodeEntry (:doc |)
+        |button $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def button $ merge ui/button
               {} $ :background-color :white
           :examples $ []
           :schema $ :: 'Dynamic
-        |link $ %{} :CodeEntry (:doc |)
+        |link $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def link $ {} (:text-decoration :underline) (:cursor :pointer)
               :color $ hsl 240 80 80
               :font-family ui/font-fancy
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.style $ :require
             [] respo-ui.core :refer $ [] hsl
             [] respo-ui.core :as ui
-    |app.twig.container $ %{} :FileEntry
+    |app.twig.container $ %{} 'FileEntry
       :defs $ {}
-        |twig-container $ %{} :CodeEntry (:doc |)
+        |twig-container $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn twig-container (db session records)
               let
@@ -1311,7 +1360,7 @@
                   {}
           :examples $ []
           :schema $ :: 'Dynamic
-        |twig-members $ %{} :CodeEntry (:doc |)
+        |twig-members $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn twig-members (sessions users)
               -> sessions $ .map-kv
@@ -1320,7 +1369,7 @@
                     [] (:user-id session) :name
           :examples $ []
           :schema $ :: 'Dynamic
-        |twig-notes-by-month $ %{} :CodeEntry (:doc |)
+        |twig-notes-by-month $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn twig-notes-by-month (data notes)
               let
@@ -1336,7 +1385,7 @@
                         = month $ :month time
           :examples $ []
           :schema $ :: 'Dynamic
-        |twig-tasks-by-week $ %{} :CodeEntry (:doc |)
+        |twig-tasks-by-week $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn twig-tasks-by-week (data tasks)
               let
@@ -1355,32 +1404,32 @@
                         &< t $ get-timestamp end-time
           :examples $ []
           :schema $ :: 'Dynamic
-        |week-millis $ %{} :CodeEntry (:doc |)
+        |week-millis $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def week-millis $ * 7 24 3600 1000
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.twig.container $ :require
             [] app.twig.user :refer $ [] twig-user
             calcit.std.rand :refer $ rand-hex-color!
             calcit.std.date :refer $ Date extract-time get-time! from-ywd from-ymd parse-time format-time get-timestamp
-    |app.twig.user $ %{} :FileEntry
+    |app.twig.user $ %{} 'FileEntry
       :defs $ {}
-        |twig-user $ %{} :CodeEntry (:doc |)
+        |twig-user $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn twig-user (user)
               -> user (dissoc :password) (dissoc :tasks)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.twig.user $ :require
             [] recollect.twig :refer $ [] deftwig
-    |app.updater $ %{} :FileEntry
+    |app.updater $ %{} 'FileEntry
       :defs $ {}
-        |updater $ %{} :CodeEntry (:doc |)
+        |updater $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn updater (db op sid op-id op-time)
               tag-match op
@@ -1405,22 +1454,22 @@
                 _ $ do (eprintln "|Unknown op:" op) db
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.updater $ :require ([] app.updater.session :as session) ([] app.updater.user :as user) ([] app.updater.router :as router) ([] app.updater.misc :as misc) ([] app.updater.task :as task) ([] app.updater.note :as note) ([] app.schema :as schema)
             [] respo-message.updater :refer $ [] update-messages
-    |app.updater.misc $ %{} :FileEntry
+    |app.updater.misc $ %{} 'FileEntry
       :defs $ {}
-        |set-today $ %{} :CodeEntry (:doc |)
+        |set-today $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn set-today (db op-data sid op-id op-time) (assoc db :today op-data)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.updater.misc)
-    |app.updater.note $ %{} :FileEntry
+    |app.updater.note $ %{} 'FileEntry
       :defs $ {}
-        |add-note $ %{} :CodeEntry (:doc |)
+        |add-note $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn add-note (db op-data sid op-id op-time)
               let
@@ -1431,7 +1480,7 @@
                 assoc-in db ([] :users user-id :notes op-id) new-note
           :examples $ []
           :schema $ :: 'Dynamic
-        |edit-note $ %{} :CodeEntry (:doc |)
+        |edit-note $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn edit-note (db op-data sid op-id op-time)
               let
@@ -1443,7 +1492,7 @@
                   fn (note) (assoc note :text text)
           :examples $ []
           :schema $ :: 'Dynamic
-        |remove-note $ %{} :CodeEntry (:doc |)
+        |remove-note $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn remove-note (db op-data sid op-id op-time)
               let
@@ -1453,35 +1502,35 @@
                   fn (notes) (dissoc notes op-data)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.updater.note $ :require ([] app.schema :as schema)
-    |app.updater.router $ %{} :FileEntry
+    |app.updater.router $ %{} 'FileEntry
       :defs $ {}
-        |change $ %{} :CodeEntry (:doc |)
+        |change $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn change (db op-data sid op-id op-time)
               assoc-in db ([] :sessions sid :router) op-data
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.updater.router)
-    |app.updater.session $ %{} :FileEntry
+    |app.updater.session $ %{} 'FileEntry
       :defs $ {}
-        |connect $ %{} :CodeEntry (:doc |)
+        |connect $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn connect (db sid op-id op-time)
               assoc-in db ([] :sessions sid)
                 merge schema/session $ {} (:id sid)
           :examples $ []
           :schema $ :: 'Dynamic
-        |disconnect $ %{} :CodeEntry (:doc |)
+        |disconnect $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn disconnect (db sid op-id op-time)
               update db :sessions $ fn (session) (dissoc session sid)
           :examples $ []
           :schema $ :: 'Dynamic
-        |remove-message $ %{} :CodeEntry (:doc |)
+        |remove-message $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn remove-message (db op-data sid op-id op-time)
               update-in db ([] :sessions sid :messages)
@@ -1489,12 +1538,12 @@
                   dissoc messages $ :id op-data
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.updater.session $ :require ([] app.schema :as schema)
-    |app.updater.task $ %{} :FileEntry
+    |app.updater.task $ %{} 'FileEntry
       :defs $ {}
-        |create-working $ %{} :CodeEntry (:doc |)
+        |create-working $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn create-working (db op-data sid op-id op-time)
               let
@@ -1503,7 +1552,7 @@
                   merge schema/task $ {} (:id op-id) (:text op-data) (:created-time op-time)
           :examples $ []
           :schema $ :: 'Dynamic
-        |finish-working $ %{} :CodeEntry (:doc |)
+        |finish-working $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn finish-working (db op-data sid op-id op-time)
               let
@@ -1519,7 +1568,7 @@
                         , tasks
           :examples $ []
           :schema $ :: 'Dynamic
-        |pend $ %{} :CodeEntry (:doc |)
+        |pend $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn pend (db op-data sid op-id op-time)
               let
@@ -1527,7 +1576,7 @@
                 update-in db ([] :users user-id :tasks :working op-data :pending?) not
           :examples $ []
           :schema $ :: 'Dynamic
-        |put-back $ %{} :CodeEntry (:doc |)
+        |put-back $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn put-back (db op-data sid op-id op-time)
               let
@@ -1543,7 +1592,7 @@
                         , tasks
           :examples $ []
           :schema $ :: 'Dynamic
-        |remove-working $ %{} :CodeEntry (:doc |)
+        |remove-working $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn remove-working (db op-data sid op-id op-time)
               let
@@ -1552,7 +1601,7 @@
                   fn (tasks) (dissoc tasks op-data)
           :examples $ []
           :schema $ :: 'Dynamic
-        |touch-working $ %{} :CodeEntry (:doc |)
+        |touch-working $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn touch-working (db op-data sid op-id op-time)
               let
@@ -1562,7 +1611,7 @@
                     if (some? task) (assoc task :touched-time op-time) nil
           :examples $ []
           :schema $ :: 'Dynamic
-        |update-working $ %{} :CodeEntry (:doc |)
+        |update-working $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn update-working (db op-data sid op-id op-time)
               let
@@ -1575,12 +1624,12 @@
                       , nil
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.updater.task $ :require ([] app.schema :as schema)
-    |app.updater.user $ %{} :FileEntry
+    |app.updater.user $ %{} 'FileEntry
       :defs $ {}
-        |log-in $ %{} :CodeEntry (:doc |)
+        |log-in $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn log-in (db op-data sid op-id op-time)
               let-sugar
@@ -1603,13 +1652,13 @@
                           :text $ str "|No user named: " username
           :examples $ []
           :schema $ :: 'Dynamic
-        |log-out $ %{} :CodeEntry (:doc |)
+        |log-out $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn log-out (db sid op-id op-time)
               assoc-in db ([] :sessions sid :user-id) nil
           :examples $ []
           :schema $ :: 'Dynamic
-        |sign-up $ %{} :CodeEntry (:doc |)
+        |sign-up $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn sign-up (db op-data sid op-id op-time)
               let-sugar
@@ -1632,7 +1681,7 @@
                         :avatar nil
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.updater.user $ :require
             [] cumulo-util.core :refer $ [] find-first

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,15 +1,19 @@
 
 {} (:calcit-version |0.13.27)
   :version |0.1.0
-  :dependencies $ {} (|Cumulo/cumulo-reel.calcit |codex/upgrade-calcit-0.13.19)
-    |Cumulo/cumulo-util.calcit |codex/fix-option-duration
+  :dependencies $ {} (|Cumulo/cumulo-reel.calcit |0.0.24)
+    |Cumulo/cumulo-util.calcit |0.0.13
     |Respo/alerts.calcit |0.10.17
     |Respo/respo-feather.calcit |0.4.4
     |Respo/respo-markdown.calcit |0.4.22
     |Respo/respo-message.calcit |0.0.13
     |Respo/respo-ui.calcit |0.7.8
-    |Respo/respo.calcit |codex/fix-global-keydown-calcit-0.13.27
+    |Respo/respo.calcit |0.16.81
+    |Respo/respo-value.calcit |0.5.0-a2
     |calcit-lang/calcit-wss |0.2.12
     |calcit-lang/calcit.std |0.2.18
+    |calcit-lang/lilac |0.5.2
+    |calcit-lang/memof |0.0.26
+    |calcit-lang/js-ffi |0.1.9
     |calcit-lang/recollect |0.0.30
     |mvc-works/ws-edn.calcit |0.0.16

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,18 +1,16 @@
 
-{} (:calcit-version |0.12.59)
-  :dependencies $ {} (|Cumulo/cumulo-reel.calcit |0.0.21)
+{} (:calcit-version |0.13.19)
+  :dependencies $ {} (|Cumulo/cumulo-reel.calcit |0.0.23)
     |Cumulo/cumulo-util.calcit |main
-    |Respo/alerts.calcit |0.10.14
-    |Respo/respo-feather.calcit |0.4.1
-    |Respo/respo-markdown.calcit |0.4.20
-    |Respo/respo-message.calcit |0.0.10
-    |Respo/respo-ui.calcit |0.7.0
-    |Respo/respo.calcit |0.16.60
-    |calcit-lang/calcit-wss |0.2.10
-    |calcit-lang/calcit.std |0.2.14
-    |calcit-lang/lilac |0.5.1
+    |Respo/alerts.calcit |0.10.17
+    |Respo/respo-feather.calcit |0.4.4
+    |Respo/respo-markdown.calcit |0.4.22
+    |Respo/respo-message.calcit |0.0.12
+    |Respo/respo-ui.calcit |0.7.7
+    |Respo/respo.calcit |0.16.72
+    |calcit-lang/calcit-wss |0.2.12
+    |calcit-lang/calcit.std |0.2.18
+    |calcit-lang/lilac |0.5.2
     |calcit-lang/memof |0.0.26
-    ; 0.0.20+ has an upstream schema bug that blocks JS codegen on Calcit 0.12.59.
-    ; Keep the latest known-good release until https://github.com/calcit-lang/recollect/issues/25 is fixed.
-    |calcit-lang/recollect |0.0.19
-    |mvc-works/ws-edn.calcit |0.0.13
+    |calcit-lang/recollect |0.0.29
+    |mvc-works/ws-edn.calcit |0.0.16

--- a/deps.cirru
+++ b/deps.cirru
@@ -12,8 +12,6 @@
     |Respo/respo-value.calcit |0.5.0-a2
     |calcit-lang/calcit-wss |0.2.12
     |calcit-lang/calcit.std |0.2.18
-    |calcit-lang/lilac |0.5.2
-    |calcit-lang/memof |0.0.26
     |calcit-lang/js-ffi |0.1.9
     |calcit-lang/recollect |0.0.30
     |mvc-works/ws-edn.calcit |0.0.16

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,16 +1,15 @@
 
-{} (:calcit-version |0.13.19)
-  :dependencies $ {} (|Cumulo/cumulo-reel.calcit |0.0.23)
-    |Cumulo/cumulo-util.calcit |main
+{} (:calcit-version |0.13.27)
+  :version |0.1.0
+  :dependencies $ {} (|Cumulo/cumulo-reel.calcit |codex/upgrade-calcit-0.13.19)
+    |Cumulo/cumulo-util.calcit |codex/fix-option-duration
     |Respo/alerts.calcit |0.10.17
     |Respo/respo-feather.calcit |0.4.4
     |Respo/respo-markdown.calcit |0.4.22
-    |Respo/respo-message.calcit |0.0.12
-    |Respo/respo-ui.calcit |0.7.7
-    |Respo/respo.calcit |0.16.72
+    |Respo/respo-message.calcit |0.0.13
+    |Respo/respo-ui.calcit |0.7.8
+    |Respo/respo.calcit |codex/fix-global-keydown-calcit-0.13.27
     |calcit-lang/calcit-wss |0.2.12
     |calcit-lang/calcit.std |0.2.18
-    |calcit-lang/lilac |0.5.2
-    |calcit-lang/memof |0.0.26
-    |calcit-lang/recollect |0.0.29
+    |calcit-lang/recollect |0.0.30
     |mvc-works/ws-edn.calcit |0.0.16

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "jiyinyiyong",
   "license": "MIT",
   "dependencies": {
-    "@calcit/procs": "^0.13.19",
+    "@calcit/procs": "^0.13.27",
     "dayjs": "^1.11.19",
     "nanoid": "^5.1.16"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "jiyinyiyong",
   "license": "MIT",
   "dependencies": {
-    "@calcit/procs": "0.12.59",
+    "@calcit/procs": "^0.13.19",
     "dayjs": "^1.11.19",
     "nanoid": "^5.1.16"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:0.12.59":
-  version: 0.12.59
-  resolution: "@calcit/procs@npm:0.12.59"
+"@calcit/procs@npm:^0.13.19":
+  version: 0.13.19
+  resolution: "@calcit/procs@npm:0.13.19"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/dd5e1b6f6481c06c92faebc9de8ca8a0938938fbb158e9a79c76bbaaf1a42e712202555d39f209e24abb25eca5e7035869ddb0e82a3c6304d1d6d4576c323c64
+  checksum: 10c0/72f17208989f8e2e78462cce625b88fcb5c1635eb04a219f49c954a7c4abc7b0c1bce186d325978a4067d3840e02f3cbf913958828a5a4c543f00bc524c9a9fd
   languageName: node
   linkType: hard
 
@@ -1056,7 +1056,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "timegrass@workspace:."
   dependencies:
-    "@calcit/procs": "npm:0.12.59"
+    "@calcit/procs": "npm:^0.13.19"
     bottom-tip: "npm:^0.1.5"
     copy-text-to-clipboard: "npm:^3.2.2"
     dayjs: "npm:^1.11.19"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.19":
-  version: 0.13.19
-  resolution: "@calcit/procs@npm:0.13.19"
+"@calcit/procs@npm:^0.13.27":
+  version: 0.13.27
+  resolution: "@calcit/procs@npm:0.13.27"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/72f17208989f8e2e78462cce625b88fcb5c1635eb04a219f49c954a7c4abc7b0c1bce186d325978a4067d3840e02f3cbf913958828a5a4c543f00bc524c9a9fd
+  checksum: 10c0/f3f2d1a3dd94797f99bec39cbf722b7d98d0308d0643f861997b1accc44fe68f5922149b268881aae1df4a3524968e3f10c58870358952bd959ff4dddcfd326a
   languageName: node
   linkType: hard
 
@@ -1056,7 +1056,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "timegrass@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.19"
+    "@calcit/procs": "npm:^0.13.27"
     bottom-tip: "npm:^0.1.5"
     copy-text-to-clipboard: "npm:^3.2.2"
     dayjs: "npm:^1.11.19"


### PR DESCRIPTION
Per `cr docs read upgrade`:
- `caps upgrade --all`: `:calcit-version` -> 0.13.19; pinned deps bumped to latest tags
- `@calcit/procs` synced to ^0.13.19 in package.json / yarn.lock
- modules re-synced via `caps`

deps.cirru audit: uses |main branch refs (kept as-is); no :dev-dependencies section.