### PR TITLE
chore: upgrade Calcit to 0.13.29

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -22,7 +22,9 @@ jobs:
         corepack prepare yarn@4.12.0 --activate
         yarn --version
 
-    - uses: calcit-lang/setup-cr@0.0.9
+    - uses: calcit-lang/setup-calcit@v1
+      with:
+        tools: calcit,caps
 
 
     - name: Install deps
@@ -30,9 +32,9 @@ jobs:
 
     - name: Validate Calcit snapshot
       run: |
-        cr calcit.cirru edit format
+        calcit calcit.cirru edit format
         git diff --exit-code -- calcit.cirru
-        cr calcit.cirru --check-only
+        calcit calcit.cirru --check-only
 
     - name: Build browser client
       run: yarn compile-page && yarn release-page

--- a/202608221531.md
+++ b/202608221531.md
@@ -1,0 +1,5 @@
+# Timegrass Calcit 0.13.29 follow-up
+
+- Replaced old branch/version dependency references with verified current commits.
+- Updated the agent guide from the removed `cr` command family to the current `calcit` CLI and canonical Snapshot workflow.
+- Verified immutable Yarn install, canonical formatting, check-only, JS generation, and Vite production build under Node 24.

--- a/202608221558.md
+++ b/202608221558.md
@@ -1,0 +1,4 @@
+# 2026-08-22 15:58
+
+- 重写现行 `llms/Respo.md` 开发指南，统一使用 `calcit` CLI 和 canonical `calcit.cirru` Snapshot。
+- 删除现行指南中将旧 Snapshot 与旧 CLI 当作工作流的示例，补充当前 agents、format、check-only、JS 和 Yarn 验证流程。

--- a/Agents.md
+++ b/Agents.md
@@ -42,8 +42,8 @@ app.comp.*          # ← ADD your UI components here
 #### 1. **Update Schema** (Define data structure)
 
 ```bash
-cr query def app.schema/user
-cr tree append-child app.schema/user -p "1" -e ":tasks (noted task ({}))"
+calcit query def app.schema/user
+calcit tree append-child app.schema/user --path "1" --code ':tasks (noted task ({}))'
 ```
 
 Add to `app.schema` namespace if needed:
@@ -60,7 +60,7 @@ def task
 #### 2. **Create Updater** (Business logic - pure function)
 
 ```bash
-cr edit def app.updater.task/add-task -e \
+calcit edit def app.updater.task/add-task --code \
   'defn add-task (db title sid op-id op-time)
     let
         user-id $ get-in db ([] :sessions sid :user-id)
@@ -78,18 +78,18 @@ cr edit def app.updater.task/add-task -e \
 
 ```bash
 # Find insertion point
-cr query def app.updater/updater
-cr tree show app.updater/updater -p "2"
+calcit query def app.updater/updater
+calcit tree show app.updater/updater --path "2"
 
 # Add new branch
-cr tree insert-before app.updater/updater -p "2,8" -e \
+calcit tree insert-before app.updater/updater --path "2,8" --code \
   '(:task/add title) (task/add-task db title sid op-id op-time)'
 ```
 
 #### 4. **Update Twig** (Control what clients see)
 
 ```bash
-cr query def app.twig.container/twig-container
+calcit query def app.twig.container/twig-container
 # Then add/modify twig logic
 ```
 
@@ -177,8 +177,8 @@ defn twig-your-feature (db session)
 **Find location**:
 
 ```bash
-cr query def app.updater/updater
-cr tree show app.updater/updater -p "2"  # tag-match cases
+calcit query def app.updater/updater
+calcit tree show app.updater/updater --path "2"  # tag-match cases
 ```
 
 **Add case** (use same structure as existing ones):
@@ -197,26 +197,26 @@ tag-match op
 ### A. Add Field to Existing Schema
 
 ```bash
-cr tree append-child app.schema/user -p "1" -e ":new-field default-value"
+calcit tree append-child app.schema/user --path "1" --code ':new-field default-value'
 ```
 
 ### B. Modify Updater Logic
 
 ```bash
 # 1. Find and read current code
-cr query def app.updater.user/log-in
+calcit query def app.updater.user/log-in
 
 # 2. Locate exact position
-cr tree show app.updater.user/log-in -p "2"
+calcit tree show app.updater.user/log-in --path "2"
 
 # 3. Replace specific node
-cr tree replace app.updater.user/log-in -p "2,1,0" -e 'new-logic here'
+calcit tree replace app.updater.user/log-in --path "2,1,0" --code 'new-logic here'
 ```
 
 ### C. Add New Twig Projection
 
 ```bash
-cr edit def app.twig.user/twig-user-profile -e \
+calcit edit def app.twig.user/twig-user-profile --code \
   'defn twig-user-profile (user)
     {}
       :id $ :id user
@@ -227,7 +227,7 @@ cr edit def app.twig.user/twig-user-profile -e \
 ### D. Wire New Operation
 
 ```bash
-cr tree insert-after app.updater/updater -p "2,5" -e \
+calcit tree insert-after app.updater/updater --path "2,5" --code \
   '(:new/operation data) (new-updater db data sid op-id op-time)'
 ```
 
@@ -298,29 +298,29 @@ defn good-twig-container (db session)
 
 ```bash
 # View schema
-cr query def app.schema/database
+calcit query def app.schema/database
 
 # Trace updater flow
-cr query usages app.updater/updater
+calcit query usages app.updater/updater
 
 # Find where something is defined
-cr query find your-function-name
+calcit query find your-function-name
 
 # See all operations
-cr query search app.updater/updater -p "tag-match" -l
+calcit query search app.updater/updater --pattern "tag-match" --limit 100
 ```
 
 ### Test Changes
 
 ```bash
 # Syntax check only (fast)
-cr --check-only
+calcit calcit.cirru --check-only
 
 # Run once and exit
-cr -1
+calcit calcit.cirru
 
 # Compile JS once
-cr -1 js
+calcit calcit.cirru js
 ```
 
 ### Server Logs (set `dev? true` in config)
@@ -416,20 +416,20 @@ dispatch! $ :: :router/change ({} (:name :profile))
 
 ```bash
 # Development cycle
-cr --check-only              # Fast syntax check
-cr -1                        # Run once
-cr js                        # Watch compile
-mode=dev cr --entry server   # Dev server
+calcit calcit.cirru --check-only              # Fast syntax check
+calcit calcit.cirru                         # Run once
+calcit calcit.cirru js                      # Compile once
+mode=dev calcit --entry server              # Dev server
 
 # Code exploration
-cr query def app.updater/updater
-cr query usages your-function
-cr query find symbol-name
+calcit query def app.updater/updater
+calcit query usages your-function
+calcit query find symbol-name
 
 # Code modification
-cr tree show path/to/func -p "2,1"
-cr tree replace path/to/func -p "2,1,0" -e 'new-code'
-cr edit def new/function -e 'defn ...'
+calcit tree show path/to/func --path "2,1"
+calcit tree replace path/to/func --path "2,1,0" --code 'new-code'
+calcit edit def new/function --code 'defn ...'
 ```
 
 ### Common Code Patterns
@@ -497,10 +497,10 @@ comp-messages (:messages session)
 ## Testing
 
 ```bash
-cr --check-only  # Syntax only (fast)
+calcit calcit.cirru --check-only  # Syntax only (fast)
 
-cr --check-only  # Syntax only (fast)
-cr -1            # Run full cycle once
+calcit calcit.cirru --check-only  # Syntax only (fast)
+calcit calcit.cirru                # Run full cycle once
 ```
 
 ---
@@ -576,7 +576,7 @@ When adding a feature:
 3. ✅ **Wire** - Add case to `app.updater/updater` tag-match
 4. ✅ **Twig** - Filter data by session in `app.twig.*`
 5. ✅ **UI** - Create Respo component in `app.comp.*`
-6. ✅ **Test** - `cr --check-only` before commit
+6. ✅ **Test** - `calcit calcit.cirru --check-only` before commit
 
 **Key Rules**:
 
@@ -584,7 +584,7 @@ When adding a feature:
 - Twigs must **filter by session** (never leak private data)
 - Always **dissoc :password** before sending to client
 - Use **`(:: :namespace/action args)`** for operations
-- Test with **`cr --check-only`** frequently
+- Test with **`calcit calcit.cirru --check-only`** frequently
 
 **Template handles** (don't need to modify often):
 
@@ -610,6 +610,6 @@ When adding a feature:
 Make sure read
 
 ```bash
-cr docs agents --full
-cr docs read respo.calcit --full
+calcit docs agents --full
+calcit docs read upgrade
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yarn watch-page
 yarn dev-page
 
 # realtime server
-mode=dev cr calcit.cirru --entry server -w
+mode=dev calcit -w calcit.cirru --entry server
 ```
 
 `calcit.cirru` now uses explicit entries: the default browser entry runs in

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,5 +1,5 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |app)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |app)
   :entries $ {}
     :default $ {} (:description "||Browser client bundle") (:init-fn 'app.client/main!) (:mode :js) (:reload-fn 'app.client/reload!)
       :feature-policy $ {}

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,15 +1,15 @@
 
 {} (:calcit-version |0.13.29)
   :version |0.1.0
-  :dependencies $ {} (|Cumulo/cumulo-reel.calcit |codex/upgrade-calcit-0.13.19)
-    |Cumulo/cumulo-util.calcit |codex/fix-option-duration
-    |Respo/alerts.calcit |0.10.19
-    |Respo/respo-feather.calcit |0.4.4
-    |Respo/respo-markdown.calcit |0.4.22
-    |Respo/respo-message.calcit |0.0.13
-    |Respo/respo-ui.calcit |0.7.9
-    |Respo/respo.calcit |codex/fix-global-keydown-calcit-0.13.27
-    |calcit-lang/calcit-wss |0.2.12
-    |calcit-lang/calcit.std |0.2.18
-    |calcit-lang/recollect |0.0.30
-    |mvc-works/ws-edn.calcit |0.0.16
+  :dependencies $ {} (|Cumulo/cumulo-reel.calcit |0d466ca41c81bfab9b455a29fc286d4f1b633e2c)
+    |Cumulo/cumulo-util.calcit |9a3ea24d00f8bf9d962cd30d599fd6074adb38f1
+    |Respo/alerts.calcit |daa4673189580217bb17982f4d96ff32ada3bd04
+    |Respo/respo-feather.calcit |2c8f8736ac3aa1b193041ad6445b16d645c8b353
+    |Respo/respo-markdown.calcit |c6b44845bbe7df7f3bd8a105db0006572cf71f6c
+    |Respo/respo-message.calcit |1635f839349e9423ea88ab3d5c6ee9f9700dcc7f
+    |Respo/respo-ui.calcit |49e5ea05acba1f5a73f5b50d8af5237d09a1f149
+    |Respo/respo.calcit |d78e3d405077d9d9250ea9e705cb11ab3b4e902f
+    |calcit-lang/calcit-wss |3a442ea936a0bfe22be1c129660ef7a2cefb0723
+    |calcit-lang/calcit.std |2b039bff85c36f3c1f8eeb7c3346804d690fb84c
+    |calcit-lang/recollect |31305b89ed98b29b1204160b460a1f9f02666857
+    |mvc-works/ws-edn.calcit |b0bf8c77c8e3f011a520f4477f96ee4b6c75063f

--- a/deps.cirru
+++ b/deps.cirru
@@ -3,11 +3,11 @@
   :version |0.1.0
   :dependencies $ {} (|Cumulo/cumulo-reel.calcit |codex/upgrade-calcit-0.13.19)
     |Cumulo/cumulo-util.calcit |codex/fix-option-duration
-    |Respo/alerts.calcit |0.10.17
+    |Respo/alerts.calcit |0.10.19
     |Respo/respo-feather.calcit |0.4.4
     |Respo/respo-markdown.calcit |0.4.22
     |Respo/respo-message.calcit |0.0.13
-    |Respo/respo-ui.calcit |0.7.8
+    |Respo/respo-ui.calcit |0.7.9
     |Respo/respo.calcit |codex/fix-global-keydown-calcit-0.13.27
     |calcit-lang/calcit-wss |0.2.12
     |calcit-lang/calcit.std |0.2.18

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,5 +1,5 @@
 
-{} (:calcit-version |0.13.27)
+{} (:calcit-version |0.13.29)
   :version |0.1.0
   :dependencies $ {} (|Cumulo/cumulo-reel.calcit |codex/upgrade-calcit-0.13.19)
     |Cumulo/cumulo-util.calcit |codex/fix-option-duration

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,15 +1,15 @@
 
 {} (:calcit-version |0.13.29)
   :version |0.1.0
-  :dependencies $ {} (|Cumulo/cumulo-reel.calcit |0d466ca41c81bfab9b455a29fc286d4f1b633e2c)
-    |Cumulo/cumulo-util.calcit |9a3ea24d00f8bf9d962cd30d599fd6074adb38f1
-    |Respo/alerts.calcit |daa4673189580217bb17982f4d96ff32ada3bd04
-    |Respo/respo-feather.calcit |2c8f8736ac3aa1b193041ad6445b16d645c8b353
-    |Respo/respo-markdown.calcit |c6b44845bbe7df7f3bd8a105db0006572cf71f6c
-    |Respo/respo-message.calcit |1635f839349e9423ea88ab3d5c6ee9f9700dcc7f
-    |Respo/respo-ui.calcit |49e5ea05acba1f5a73f5b50d8af5237d09a1f149
-    |Respo/respo.calcit |d78e3d405077d9d9250ea9e705cb11ab3b4e902f
-    |calcit-lang/calcit-wss |3a442ea936a0bfe22be1c129660ef7a2cefb0723
-    |calcit-lang/calcit.std |2b039bff85c36f3c1f8eeb7c3346804d690fb84c
-    |calcit-lang/recollect |31305b89ed98b29b1204160b460a1f9f02666857
-    |mvc-works/ws-edn.calcit |b0bf8c77c8e3f011a520f4477f96ee4b6c75063f
+  :dependencies $ {} (|Cumulo/cumulo-reel.calcit |0.0.24)
+    |Cumulo/cumulo-util.calcit |0.0.13
+    |Respo/alerts.calcit |0.10.19
+    |Respo/respo-feather.calcit |0.4.4
+    |Respo/respo-markdown.calcit |0.4.22
+    |Respo/respo-message.calcit |0.0.13
+    |Respo/respo-ui.calcit |0.7.9
+    |Respo/respo.calcit |0.16.81
+    |calcit-lang/calcit-wss |0.2.12
+    |calcit-lang/calcit.std |0.2.18
+    |calcit-lang/recollect |0.0.30
+    |mvc-works/ws-edn.calcit |0.0.16

--- a/history/202608221220-upgrade-01329.md
+++ b/history/202608221220-upgrade-01329.md
@@ -1,0 +1,5 @@
+# Calcit 0.13.29 升级
+
+- 将 Calcit、`@calcit/procs`、CI action 和页面编译命令统一到 0.13.29 / `calcit` / `caps`，显式保留 watch 模式。
+- 保持 canonical `calcit.cirru`，保留当前 Cumulo 分支依赖以便后续 PR 联调，并更新 Yarn lock。
+- 本地通过依赖同步、check-only 和页面 JS codegen；Vite build 需 Node 20.19+ 或 Node 22/24，CI 已使用 Node 24。

--- a/history/202608221713-simplify-respo-guide.md
+++ b/history/202608221713-simplify-respo-guide.md
@@ -1,0 +1,5 @@
+# 2026-08-22 17:13 — Simplify the Respo agent guide
+
+- Keep only Timegrass-specific Respo discovery and validation commands in `llms/Respo.md`.
+- Point detailed Calcit syntax, CLI, tree, and type guidance to the current `calcit docs` manuals so this project does not carry a stale duplicate.
+- Explicitly prohibit new references to `cr`, `compact.cirru`, `lilac`, and `memof`.

--- a/history/2026082218-formal-dependency-versions.md
+++ b/history/2026082218-formal-dependency-versions.md
@@ -1,0 +1,6 @@
+# 2026-08-22 18:00 — Replace pinned dependency hashes with releases
+
+- Updated the root Calcit dependencies from commit hashes to published SemVer versions.
+- Kept the dependency graph on the current Calcit 0.13.29 toolchain.
+- Verified the canonical snapshot with `calcit edit format`, `--check-only`, and JavaScript code generation.
+- The project still reports its pre-existing high Dynamic-type ratio; this dependency-only change does not alter those definitions.

--- a/llms/Respo.md
+++ b/llms/Respo.md
@@ -1,916 +1,133 @@
-# Respo Development Guide for LLM Agents
+# Respo Development Guide for Calcit Agents
 
-**🤖 This guide is specifically designed for LLM agents to develop, debug, and maintain Respo applications.**
+This guide describes the current Respo project workflow. The project source is
+stored in the canonical `calcit.cirru` Snapshot. Keep that file as the only
+Snapshot representation and do not introduce a second serialized source file.
 
-📚 **Related Documentation**:
+## Before editing
 
-- [← Back to README](../README.md)
-- [Beginner Guide](./beginner-guide.md)
-- [CLI Tools Reference](../Agents.md)
-- [API Reference](./api.md)
-
----
-
-## Project Structure
-
-The Respo project is a virtual DOM library written in Calcit-js, containing:
-
-- **Main codebase**: `compact.cirru` (2314 lines) - serialized source code
-- **Compiled source**: `calcit.cirru` (13806 lines) - full AST representation
-- **Namespaces**: 33 total namespaces organized by functionality
-- **Version**: 0.16.21
-- **Dependencies**: memof (memoization), lilac (UI utilities), calcit-test (testing)
-
-### Core Namespace Organization
-
-**User-facing APIs** (what you typically use):
-
-- `respo.core` - Core APIs: defcomp, div, render!, clear-cache!, etc.
-- `respo.comp.space` - Utility component comp-space (=<)
-- `respo.comp.inspect` - Debugging component comp-inspect
-- `respo.render.html` - HTML generation: make-string, make-html
-
-**Application layer** (in example app):
-
-- `respo.app.core` - Main application logic (\*store, dispatch!, render-app!)
-- `respo.app.schema` - Data structures and schemas
-- `respo.app.updater` - State management and updates
-- `respo.app.comp.*` - Application components (container, task, todolist, wrap, zero)
-- `respo.app.style.widget` - Application styles
-
-**Rendering and internal** (low-level):
-
-- `respo.render.diff` - Find differences between virtual DOM trees
-- `respo.render.dom` - DOM element creation and manipulation
-- `respo.render.effect` - Component lifecycle effects
-- `respo.render.patch` - Apply DOM patches
-- `respo.controller.client` - Client-side state management (activate-instance!, patch-instance!)
-- `respo.controller.resolve` - Event handling and resolution
-
-**Utilities**:
-
-- `respo.util.dom` - DOM utilities
-- `respo.util.format` - Element formatting (purify-element, mute-element)
-- `respo.util.list` - List utilities (map-val, map-with-idx)
-- `respo.util.detect` - Type detection (component?, element?, effect?)
-- `respo.css` - CSS utilities
-- `respo.cursor` - Cursor management for nested states
-
----
-
-## Essential Calcit CLI Commands for Development
-
-### 1. Exploration and Discovery
+Read the current agent guidance before using any Calcit mutation command:
 
 ```bash
-# List all namespaces in the project
-cr query ns
-
-# Get details about a specific namespace (imports, definitions)
-cr query ns respo.core
-cr query ns respo.app.core
-
-# List all definitions in a namespace
-cr query defs respo.core
-cr query defs respo.app.updater
-
-# Quick peek at a definition (signature, parameters, docs)
-cr query peek respo.core/defcomp
-cr query peek respo.core/render!
-
-# Get complete definition as JSON syntax tree
-cr query def respo.core/render!
-cr query def respo.app.core/dispatch!
-
-# Search for a symbol across all namespaces
-cr query find render!
-cr query find *store
-
-# Find all usages of a specific definition
-cr query usages respo.core/render!
-cr query usages respo.app.core/dispatch!
+calcit docs agents --full
+calcit docs read upgrade
 ```
 
-### 2. Precise Code Navigation (tree pattern)
+Use the current `calcit` CLI. Normal execution is a single run; add `-w` or
+`--watch` only when a watcher is explicitly needed.
 
-When you need to understand or modify specific parts of a definition:
+## Project discovery
+
+Project-aware commands take `calcit.cirru` as their entry file:
 
 ```bash
-# Step 1: Read the complete definition first
-cr query def respo.app.updater/updater
-
-# Step 2: Use tree show to examine the structure (limit depth to reduce output)
-cr tree show respo.app.updater/updater -p "" -d 1    # View root level
-
-# Step 3: Dive deeper into specific indices
-cr tree show respo.app.updater/updater -p "2" -d 1   # Check 3rd element
-cr tree show respo.app.updater/updater -p "2,1" -d 1 # Check 2nd child of 3rd element
-
-# Step 4: Confirm target location before editing
-cr tree show respo.app.updater/updater -p "2,1,0"    # Final confirmation
-
-# Step 5: Use tree commands for surgical modifications
-# JSON inline (recommended)
-cr tree replace respo.app.updater/updater -p "2,1,0" -j '"new-value"'
-# Or from stdin
-echo '"new-value"' | cr tree replace respo.app.updater/updater -p "2,1,0" -s -J
+calcit calcit.cirru query ns
+calcit calcit.cirru query ns respo.core
+calcit calcit.cirru query defs respo.core
+calcit calcit.cirru query peek respo.core/defcomp
+calcit calcit.cirru query def respo.core/render!
+calcit calcit.cirru query find render!
+calcit calcit.cirru query usages respo.core/render!
+calcit calcit.cirru query error
 ```
 
-echo '["defn", "hello", [], ["println", "|Hello"]]' | cr edit def respo.app.core/hello -s -J
-
-### 3. Code Modification (Agent Optimized)
-
-**Best Practice: Use JSON AST**
-For LLM Agents, **JSON inline (`-j`) is the most reliable method** for code generation. It avoids whitespace/indentation ambiguity inherent in Cirru.
-
-**Input Modes:**
-
-- `-j '<json>'`: **Recommended.** Inline JSON string. Escape quotes carefully.
-- `-e '<text>'`: Inline Cirru one-liner. Good for short, simple expressions.
-- `-f <file>` / `-s`: Read from file/stdin (defaults to Cirru).
-- `-J`: Combine with `-f`/`-s` to indicate JSON input.
-
-**JSON AST Structure Guide:**
-
-- Function: `(defn f (x) x)` -> `["defn", "f", ["x"], "x"]`
-- Map: `{:a 1}` -> `["{}", [":a", "1"]]`
-- String: `"|hello"` -> `"|hello"` (in JSON string: `"\"|hello\""`)
-- Keyword: `:key` -> `":key"`
-
-**Common Commands:**
+For Cirru syntax experiments that do not load the project, use the top-level
+Cirru tools:
 
 ```bash
-# 1. Add/Update Definition (JSON)
-# (defn greet (name) (println "|Hello" name))
-cr edit def respo.demo/greet -j '["defn", "greet", ["name"], ["println", "\"|Hello\"", "name"]]'
-
-# 2. Add Definition (Cirru One-liner - risky for complex code)
-cr edit def respo.demo/simple -e 'defn simple (x) (+ x 1)'
-
-# 3. Update Imports (JSON)
-# (ns respo.demo (:require [respo.core :refer [div span]]))
-cr edit imports respo.demo -j '[["respo.core", ":refer", ["div", "span"]]]'
-
-# 4. Remove Definition
-cr edit rm-def respo.demo/old-fn
-
-# 5. Namespace Operations
-cr edit add-ns respo.new-feature
-cr edit rm-ns respo.deprecated
+calcit cirru parse -e 'defn f (x) (+ x 1)'
+calcit cirru format '["div", {}, ["<>", "hello"]]'
 ```
 
-**💡 Pro Tip: Validation**
-If unsure about the JSON structure, generate it from Cirru first:
+## Inspecting and editing definitions
+
+Read the complete definition before making a structural change. Use the
+project-aware `tree` and `edit` commands for Snapshot changes; do not edit the
+serialized Snapshot with a text editor.
 
 ```bash
-cr cirru parse -O 'defn f (x) (+ x 1)'
-# Output: ["defn", "f", ["x"], ["+", "x", "1"]]
+calcit calcit.cirru query def respo.app.updater/updater
+calcit calcit.cirru tree show respo.app.updater/updater -p "" -d 1
+calcit calcit.cirru tree show respo.app.updater/updater -p "2,1" -d 1
+
+# Prefer content-based tree operations when available.
+calcit calcit.cirru tree search-replace respo.app.updater/updater \
+  --code 'old-value' --with 'new-value'
+
+calcit calcit.cirru edit add-ns respo.app.feature-x
+calcit calcit.cirru edit add-import respo.app.feature-x \
+  --code 'respo.core :refer $ defcomp div span'
 ```
 
-### 4. Project Configuration
+For larger edits, put the Cirru or JSON input in a temporary file and pass it
+with `--file`. Use `--code` for short snippets. The current mutation commands
+do not require a legacy standard-input flag.
+
+After every Snapshot edit, format and inspect the diff:
 
 ```bash
-# Get project configuration (init-fn, reload-fn, version)
-cr config show
-
-# Set project configuration
-cr config version "0.16.22"
-cr config init-fn "respo.main/main!"
-cr config reload-fn "respo.main/reload!"
+calcit calcit.cirru edit format
+git diff -- calcit.cirru
 ```
 
-### 5. Workflow: Building From Scratch
+When replacing a definition or moving namespaces, prefer the dedicated
+`edit` commands and use `tree rewrite` for replacements that need references
+to original nodes. For sibling index operations, work from the end toward the
+beginning or re-query paths after each mutation.
 
-Follow this sequence to create a new feature cleanly:
+## Validation
 
-**Step 1: Create Namespace**
+Install dependencies from `deps.cirru`, then run the canonical checks:
 
 ```bash
-cr edit add-ns respo.app.feature-x
+caps --ci
+calcit calcit.cirru edit format
+git diff --exit-code -- calcit.cirru
+calcit calcit.cirru --check-only
+calcit calcit.cirru analyze deprecated --summary-only --format json
+calcit calcit.cirru js
+yarn install --immutable
+yarn vite build --base=./
 ```
 
-**Step 2: Add Imports**
-Define dependencies (e.g., `respo.core`).
+`calcit eval` is useful for small semantic or type experiments, but it is not
+a substitute for running the complete project. Keep the snippet top-level
+and remember that `let` bindings use pairs, for example:
 
 ```bash
-# Cirru: (:require [respo.core :refer [defcomp div span]])
-cr edit imports respo.app.feature-x -j '[["respo.core", ":refer", ["defcomp", "div", "span"]]]'
+calcit calcit.cirru eval 'let ((x 1)) (+ x 2)'
 ```
 
-**Step 3: Create Component**
-Define the component logic.
+Warnings from type checking are intentional failures in validation. Inspect
+`.calcit/error.cirru` for the full diagnostic context.
+
+## Runtime and release workflow
+
+The normal JavaScript build is:
 
 ```bash
-# Cirru: (defcomp comp-x (data) (div {} (<> "Feature X")))
-cr edit def respo.app.feature-x/comp-x -j '["defcomp", "comp-x", ["data"], ["div", ["{}"], ["<>", "\"|Feature X\""]]]'
+calcit calcit.cirru js
+yarn vite build --base=./
 ```
 
-**Step 4: Verify**
-
-```bash
-cr query def respo.app.feature-x/comp-x
-cr --check-only
-```
-
-**Step 5: Integrate**
-Mount or use it in `respo.app.comp.container`.
-
-```bash
-# 1. Add import to container ns
-cr edit require respo.app.comp.container respo.app.feature-x
-
-# 2. Add usage (using surgical edit)
-# Find where to insert using `cr tree show ...`
-# cr tree insert-child ... -j '["respo.app.feature-x/comp-x", "data"]'
-```
-
-### 6. Documentation and Language
-
-```bash
-# Check for syntax errors and warnings
-cr --check-only
-cr js --check-only
-
-# Get language documentation
-cr docs api render!
-cr docs ref component
-cr docs list-api     # List all API docs
-cr docs list-guide   # List all guide docs
-
-# Parse Cirru code to JSON (for understanding syntax)
-cr cirru parse '(div {} (<> "hello"))'
-
-# Format JSON to Cirru code
-cr cirru format '["div", {}, ["<>", "hello"]]'
-
-# Parse EDN to JSON
-cr cirru parse-edn '{:a 1 :b [2 3]}'
-
-# Show Cirru syntax guide (read before generating Cirru)
-cr cirru show-guide
-```
-
-### 6. Library Management
-
-```bash
-# List official libraries
-cr libs
-
-# Search libraries by keyword
-cr libs search router
-
-# Read library README from GitHub
-cr libs readme respo
-
-# Install/update dependencies
-caps
-```
-
-### 7. Code Analysis
-
-```bash
-# Call graph analysis from init-fn (or custom root)
-cr analyze call-graph
-cr analyze call-graph --root app.main/main! --ns-prefix app. --include-core --max-depth 5 --format json
-
-# Call count statistics
-cr analyze count-calls
-cr analyze count-calls --root app.main/main! --ns-prefix app. --include-core --format json --sort count
-```
-
----
-
-## Development Workflow for LLM Agents
-
-### Step 1: Understand the Problem
-
-```bash
-# Always start by exploring related code
-cr query ns respo.app.updater             # Understand state management
-cr query find my-function-name            # Find where it's defined/used
-cr query usages respo.core/render!        # See how render! is used
-```
-
-### Step 2: Implement the Solution
-
-Use the **precise editing pattern** for complex changes:
-
-```bash
-# 1. Read the whole definition
-cr query def namespace/function-name
-
-# 2. Map out the structure with tree show
-cr tree show namespace/function-name -p "" -d 1
-
-# 3. Navigate to target position
-cr tree show namespace/function-name -p "2,1" -d 1
-
-# 4. Make the change (JSON inline recommended)
-cr tree replace namespace/function-name -p "2,1,0" -j '["new", "code"]'
-
-# Or from stdin (JSON format)
-echo '["new", "code"]' | cr tree replace namespace/function-name -p "2,1,0" -s -J
-
-# 5. Verify
-cr tree show namespace/function-name -p "2,1"
-```
-
-### Step 3: Test and Validate
-
-```bash
-# Check syntax without running
-cr --check-only
-
-# Compile to JavaScript and check for errors
-cr js --check-only
-
-# Run the app once to test
-cr -1
-
-# Compile to JavaScript once
-cr -1 js
-
-# Watch mode (will call reload! on code changes)
-cr
-```
-
-### Step 4: Debug Issues
-
-```bash
-# Check for error messages
-cr query error
-
-# Read error stack traces
-cat .calcit-error.cirru  # (if it exists)
-
-# Search for the problematic code
-cr query find problem-symbol
-cr query usages namespace/definition
-
-# Review the definition in detail
-cr query def namespace/definition
-```
-
----
-
-## Common Patterns and Best Practices
-
-### 1. Component Definition Pattern
-
-**Cirru (Read):**
-
-```cirru
-; Standard component structure
-defcomp comp-name (param1 param2 & options)
-  div $ {}
-    :class-name "|component-name"
-    :style $ comp-style
-  <> "|Content"
-```
-
-**JSON AST (Write - for `cr edit`):**
-
-```json
-[
-  "defcomp",
-  "comp-name",
-  ["param1", "param2", "&", "options"],
-  [
-    "div",
-    ["{}", [":class-name", "|component-name"], [":style", "comp-style"]],
-    ["<>", "|Content"]
-  ]
-]
-```
-
-### 2. State Management Pattern
-
-```cirru
-; Define store atom at app.core level
-defatom *store $ {}
-  :states $ {}
-  :data $ {}
-
-; Create dispatcher
-defn dispatch! (op)
-  reset! *store (updater @*store op)
-
-; Updater function pattern
-defn updater (store op)
-  tag-match op
-    (:action-name value) $
-      assoc store :data (process-action (:data store) value)
-    (:nested-action id op2) $
-      update-in store [:data :nested id] (process-nested op2)
-    _ store
-```
-
-### 3. Rendering Pattern
-
-```cirru
-; Initial render
-defn render-app! ()
-  render! mount-point (comp-container @*store) dispatch!
-
-; Watch for store changes
-add-watch *store :changes $ fn ()
-  render-app!
-
-; Hot reload with cache clearing
-defn reload! ()
-  remove-watch *store :changes
-  add-watch *store :changes $ fn ()
-    render-app!
-  clear-cache!
-  render-app!
-```
-
-### 4. DOM Element Creation
-
-```cirru
-; Using predefined elements (defn wrappers for create-element)
-div $ {} (<> "text")
-button $ {} (<> "Click me")
-input $ {:value "|default"}
-span $ {:class-name "|style-name"} (<> "content")
-
-; Dynamic elements with create-element
-create-element :custom-tag $ {:prop-name "|value"}
-  <> "|child"
-
-; List rendering with list->
-list-> $ {}
-  :style $ {} (:display "|flex")
-  , $ {}
-    :a $ comp-item item-1
-    :b $ comp-item item-2
-    :c $ comp-item item-3
-```
-
-### 5. Styling Pattern
-
-```cirru
-; Define styles as maps
-def style-container $ {}
-  :display "|flex"
-  :padding "|10px"
-  :background-color "|#f0f0f0"
-
-; Conditional styles
-defn style-for-state (state)
-  if (= state :active)
-    assoc style-container :background-color "|#3388ff"
-    style-container
-
-; Merge styles
-let
-  base $ {} (:color "|black")
-  extended $ merge base $ {} (:font-size 14)
-  extended
-```
-
-### 6. Event Handling
-
-```cirru
-; Simple click handler
-div
-  {}
-    :on-click $ fn (e dispatch!)
-      dispatch! [:button-clicked]
-
-; Input with value tracking
-input
-  {}
-    :value "|current-value"
-    :on-input $ fn (e dispatch!)
-      let
-        value (e.target.value)
-      dispatch! [:input-changed value]
-
-; Keyboard events
-div
-  {}
-    :on-keydown $ fn (e dispatch!)
-      when (= (e.key) "|Enter")
-        dispatch! [:submit-form]
-```
-
----
-
-## Debugging Common Issues
-
-### Issue: Component not re-rendering
-
-**Diagnosis**:
-
-```bash
-# Check if render-app! is being called
-cr query find render-app!
-cr query usages respo.main/render-app!
-
-# Verify store watcher is set up
-cr query def respo.app.core/dispatch!
-cr query def respo.main/main!
-```
-
-**Solution Pattern**:
-
-```cirru
-; Ensure watch is on *store
-add-watch *store :changes $ fn ()
-  render-app!
-
-; Ensure clear-cache! is called on reload
-defn reload! ()
-  remove-watch *store :changes
-  clear-cache!
-  add-watch *store :changes $ fn ()
-    render-app!
-  render-app!
-```
-
-### Issue: State not updating
-
-**Diagnosis**:
-
-```bash
-# Check updater function logic
-cr query def respo.app.updater/updater
-
-# Verify dispatch! is calling updater correctly
-cr query def respo.app.core/dispatch!
-
-# Check the state path in component
-cr query def respo.app.comp.container/comp-container
-```
-
-**Solution Pattern**:
-
-```cirru
-; Verify tag-match pattern matches dispatched action
-tag-match op
-  (:action-name params) $
-    ; Make sure return value is updated store
-    assoc store :data new-value
-  _ store  ; Default case needed!
-
-; Ensure dispatch! is called with correct tuple
-dispatch! [:action-name actual-value]
-```
-
-### Issue: Component effects not triggering
-
-**Diagnosis**:
-
-```bash
-# Check effect definition
-cr query def respo.core/defeffect  # macro documentation
-
-# Find effect in component
-cr query find my-effect
-cr query usages respo.app.comp.task/my-effect
-```
-
-**Solution Pattern**:
-
-```cirru
-; Effects must be first in component body
-defcomp comp-with-effect (props)
-  []
-    effect-name param1 param2  ; First!
-    div $ {}                   ; Then render
-      <> "|content"
-
-; Effect must match action lifecycle
-defeffect my-effect (initial-value)
-  (action element at-place?)
-  when (= action :mount)
-    do (println "|mounted")
-  when (= action :update)
-    do (println "|updated")
-```
-
-### Issue: Hot reload breaking state
-
-**Diagnosis**:
-
-```bash
-# Check reload! function
-cr query def respo.main/reload!
-
-# Verify clear-cache! is called
-cr query usages respo.core/clear-cache!
-```
-
-**Solution Pattern**:
-
-```cirru
-; clear-cache! must be called during reload
-defn reload! ()
-  remove-watch *store :changes
-  clear-cache!  ; Critical!
-  add-watch *store :changes $ fn ()
-    render-app!
-  render-app!
-```
-
----
-
-## Modification Strategy: Safe Editing Guide
-
-### Before any edit, follow this checklist:
-
-1. **Understand the context**
-
-   ```bash
-   cr query ns namespace-name  # See imports and doc
-   cr query peek namespace-name/def-name  # See signature
-   ```
-
-2. **Map the exact location**
-
-   ```bash
-   cr tree show namespace-name/def-name -p "" -d 2  # Overview
-   cr tree show namespace-name/def-name -p "2" -d 2  # Check section
-   cr tree show namespace-name/def-name -p "2,1" -d 2  # Precise location
-   ```
-
-3. **Make surgical change**
-
-```bash
-# JSON inline (recommended)
-cr tree replace namespace-name/def-name -p "2,1,0" -j '"new-value"'
-
-# Or from stdin (JSON format)
-echo '"new-value"' | cr tree replace namespace-name/def-name -p "2,1,0" -s -J
-```
-
-4. **Verify immediately**
-   ```bash
-   cr tree show namespace-name/def-name -p "2,1"  # Confirm change
-   cr --check-only  # Verify syntax
-   ```
-
-### Common edit operations:
-
-```bash
-# Replace a value (JSON inline)
-cr tree replace ns/def -p "2,1,0" -j '"new-value"'
-
-# Insert before a position (JSON)
-cr tree insert-before ns/def -p "2,1" -j '["new", "element"]'
-
-# Insert after a position (JSON)
-cr tree insert-after ns/def -p "2,1" -j '["new", "element"]'
-
-# Delete a node
-cr tree delete ns/def -p "2,1,0"
-
-# Insert as child (first child)
-cr tree insert-child ns/def -p "2,1" -j '"child-value"'
-
-# Append as child (last child, from stdin)
-echo '"child-value"' | cr tree append-child ns/def -p "2,1" -s -J
-```
-
----
-
-## Testing and Validation
-
-### Basic validation
-
-```bash
-# Syntax check only (no execution)
-cr --check-only
-
-# Check JavaScript compilation
-cr js --check-only
-
-# Run application once
-cr -1
-
-# Compile to JS once
-cr -1 js
-```
-
-### Test-driven development
-
-```bash
-# Look at test files
-cr query defs respo.test.main
-cr query def respo.test.main/test-fn
-
-# Run tests
-cr -1  ; (if init-fn runs tests)
-```
-
-### Error diagnosis
-
-```bash
-# View error file
-cr query error
-cat .calcit-error.cirru
-
-# Search for the problematic definition
-cr query find problem-name
-
-# Check the full definition
-cr query def namespace/problem-name
-
-# Validate dependencies
-cr query ns namespace-name  # Check imports
-```
-
----
-
-## Important Notes for LLM Agents
-
-### ⚠️ Critical Rules
-
-1. **NEVER directly edit `calcit.cirru` or `compact.cirru`** with text editors
-   - Use `cr edit` commands instead
-   - These are serialized AST structures, not human-readable code
-
-2. **ALWAYS use relative paths for documentation links**
-   - Use `../` and `../../` for navigation
-   - This allows easy file discovery for LLM tools
-
-3. **ALWAYS check syntax before assuming it's correct**
-
-   ```bash
-   cr --check-only
-   ```
-
-4. **ALWAYS verify modifications work**
-
-   ```bash
-   cr tree show namespace/def -p "modified-path"  # Confirm change
-   cr --check-only  # Check syntax
-   cr -1  # Test run
-   ```
-
-5. **Use peek before def** to reduce token consumption
-   ```bash
-   cr query peek ns/def  # Light summary
-   cr query def ns/def  # Full AST (use only if needed)
-   ```
-
-### 🎯 Optimization Tips for Token Usage
-
-```bash
-# Fast exploration with limited output
-cr query peek respo.core/defcomp              # 5-10 lines
-cr query defs respo.app.updater               # Quick list
-
-# Slower but comprehensive
-cr query def respo.app.updater/updater        # Full JSON AST
-
-# Use -d flag to limit JSON depth
-cr tree show ns/def -p "2,1" -d 1            # Shallow
-cr tree show ns/def -p "2,1" -d 3            # Medium
-cr tree show ns/def -p "2,1"                 # Full (default)
-
-# Search before diving deep
-cr query find my-function                     # Find location first
-cr query usages ns/def                        # See usage patterns
-```
-
-### 📖 Documentation Strategy
-
-When stuck, use these resources in order:
-
-1. This file (Respo-Agent.md) - you are here
-2. [README.md](../README.md) - Project overview and index
-3. [Beginner Guide](./beginner-guide.md) - Conceptual introduction
-4. [API Reference](./api.md) - Specific API documentation
-5. [Guide docs](./guide/) - Detailed topics
-6. `cr docs api <keyword>` - Language documentation
-7. Project code itself: `cr query ns <namespace>`
-
----
-
-## Quick Reference
-
-### Most Used Commands
-
-```bash
-# Exploration (read-only, no changes)
-cr query ns                              # List namespaces
-cr query ns respo.core                   # Read namespace details
-cr query defs respo.app.core             # List definitions
-cr query peek respo.core/render!         # Quick peek
-cr query def respo.core/render!          # Full definition
-cr query find render!                    # Search globally
-cr query usages respo.core/render!       # Find usages
-
-# Navigation (precise editing)
-cr tree show ns/def -p "" -d 1           # View structure
-cr tree show ns/def -p "2,1" -d 1        # Drill down
-cr tree show ns/def -p "2,1,0"           # Confirm target
-
-# Modification (careful!)
-cr edit def ns/def -j '["defn", "func", [], "body"]'
-cr tree replace ns/def -p "2,1,0" -j '"value"'
-cr edit rm-def ns/def
-
-# Validation
-cr --check-only                          # Check syntax
-cr query error                           # View errors
-cr -1                                    # Test run
-```
-
-### File Paths in Documentation
-
-When referring to files from within `docs/`:
-
-- `./` - same directory
-- `../` - parent (docs/ to root)
-- `../../` - grandparent (docs/apis/ to root)
-
-Example from `docs/apis/defcomp.md`:
-
-```markdown
-- [Back to README](../../README.md)
-- [API Overview](../api.md)
-- [Another API](./render!.md)
-```
-
----
-
-This guide evolves as the project grows. Last updated: 2025-12-22
-
-# Calcit & Respo 开发避坑指南
-
-本文档总结了在 Calcit 和 Respo 开发过程中遇到的常见问题和最佳实践。
-
-## 1. 字符串语法 (String Syntax)
-
-Calcit 使用 `|` 前缀来表示字符串字面量。
-
-- **正确**: `|Hello` (编译为 `"Hello"`)
-- **正确**: `"Hello"` (标准 Cirru 字符串，编译为 `"Hello"`)
-- **错误**: `Hello` (会被解析为 Symbol)
-
-**CLI 操作注意**:
-在使用 `cr tree replace` 修改字符串时，推荐使用 `|` 前缀或 `--json-leaf` 确保类型正确。
-
-```bash
-# 推荐：使用 | 前缀
-cr tree replace ... -e "|Get Started"
-
-# 推荐：使用 --json-leaf 明确指定为叶子节点
-cr tree replace ... -e '"Get Started"' --json-leaf
-```
-
-如果直接使用 `-e '"Get Started"'` 且不加 `--json-leaf`，可能会被解析为包含引号的字符串 `"\"Get Started\""`，导致显示多余引号。
-
-## 2. Respo 文本渲染 (Text Rendering)
-
-Respo 的 HTML 标签（如 `div`, `span`, `button`）**不能直接接受原始字符串作为子节点**。
-
-**错误写法** (会导致 `Invalid data in elements tree`):
-
-```cirru
-div ({})
-  |SomeText
-```
-
-**正确写法 1: 使用 `:inner-text` 属性** (推荐用于纯文本标签)
-
-```cirru
-div $ {} (:inner-text |SomeText)
-```
-
-**正确写法 2: 使用 `<>` 组件** (推荐用于混合内容)
-
-```cirru
-div ({})
-  <> |SomeText
-  span $ {} (:inner-text |Other)
-```
-
-## 3. 样式定义 (Styles)
-
-在 `defstyle` 中定义样式时：
-
-- **数值属性**: 像 `font-weight` 这样的属性，如果使用数字（如 `700`），确保它是数字类型而不是字符串。
-  - 错误: `(:font-weight |bold)` (如果库不支持)
-  - 正确: `(:font-weight 700)`
-
-## 4. CLI 调试技巧
-
-- **检查代码**: `cr js --check-only`
-  - 这是一个非常快速的检查命令，能发现未定义的变量 (Warnings) 和语法错误，而不会生成 JS 文件。
-  - **务必关注 Warnings**: 很多运行时错误（如 `unknown head`）都是因为使用了未定义的 Symbol（可能是忘记加 `|` 前缀的字符串）。
-
-- **查看节点结构**: `cr tree show <ns/def> -p <path>`
-  - 在修改前，先查看目标节点的结构（是 `list` 还是 `leaf`），确认路径是否正确。
-
-- **精确修改**: `cr tree replace`
-  - 配合 `-p` 路径参数进行精确修改，避免破坏周围结构。
-
-## 5. 命名空间 (Namespaces)
-
-- **修改 Imports**: 使用 `cr edit imports <ns> -j '...'`
-  - 这是修改 `:require` 最安全的方式。
-  - 如果遇到 `invalid ns form` 错误，通常是因为 `ns` 定义格式被破坏，可以尝试清空 imports 再重新添加。
+Use `calcit calcit.cirru -w` or `calcit calcit.cirru js -w` only for an
+explicit watch session. Keep Node and Yarn versions aligned with
+`packageManager` and the repository workflow; CI should activate Corepack
+before Yarn commands.
+
+When changing dependencies, update `deps.cirru`, run `caps --ci`, and verify
+the generated project module view. Do not hand-edit generated module contents.
+
+## Debugging checklist
+
+1. Run `calcit docs agents --full` and `calcit docs read upgrade` if command
+   behavior is unclear.
+2. Use `query def`, `query usages`, and `tree show` before editing.
+3. Re-run `edit format`, `--check-only`, and JavaScript generation after each
+   Snapshot change.
+4. Check `.calcit/error.cirru` when a command reports a shortened error.
+5. Keep stdout free of diagnostics when validating scripts that consume JSON.
+
+The project is maintained with the canonical Calcit Snapshot and the current
+`calcit` command family. Examples in older notes are historical and should not
+be copied into new workflows.

--- a/llms/Respo.md
+++ b/llms/Respo.md
@@ -1,133 +1,55 @@
 # Respo Development Guide for Calcit Agents
 
-This guide describes the current Respo project workflow. The project source is
-stored in the canonical `calcit.cirru` Snapshot. Keep that file as the only
-Snapshot representation and do not introduce a second serialized source file.
+This project stores its source in the canonical `calcit.cirru` Snapshot. Keep
+that as the only serialized source file; do not add or restore `compact.cirru`.
 
 ## Before editing
 
-Read the current agent guidance before using any Calcit mutation command:
+Use the current Calcit CLI and read its live guidance before any Snapshot
+mutation:
 
 ```bash
 calcit docs agents --full
 calcit docs read upgrade
 ```
 
-Use the current `calcit` CLI. Normal execution is a single run; add `-w` or
-`--watch` only when a watcher is explicitly needed.
+For detailed Calcit syntax, tree editing, type analysis, and CLI options, use
+`calcit docs read <topic>` or `calcit docs search <keyword>` instead of
+duplicating those manuals here.
 
-## Project discovery
+## Respo-specific discovery
 
-Project-aware commands take `calcit.cirru` as their entry file:
+Use the project Snapshot explicitly when inspecting Respo code:
 
 ```bash
-calcit calcit.cirru query ns
 calcit calcit.cirru query ns respo.core
 calcit calcit.cirru query defs respo.core
-calcit calcit.cirru query peek respo.core/defcomp
-calcit calcit.cirru query def respo.core/render!
-calcit calcit.cirru query find render!
+calcit calcit.cirru query def respo.core/defcomp
 calcit calcit.cirru query usages respo.core/render!
-calcit calcit.cirru query error
 ```
 
-For Cirru syntax experiments that do not load the project, use the top-level
-Cirru tools:
+Prefer the installed Respo module documentation for API details. Keep changes
+within the application namespaces unless the task explicitly targets the
+Respo library.
 
-```bash
-calcit cirru parse -e 'defn f (x) (+ x 1)'
-calcit cirru format '["div", {}, ["<>", "hello"]]'
-```
+## Editing and validation
 
-## Inspecting and editing definitions
-
-Read the complete definition before making a structural change. Use the
-project-aware `tree` and `edit` commands for Snapshot changes; do not edit the
-serialized Snapshot with a text editor.
-
-```bash
-calcit calcit.cirru query def respo.app.updater/updater
-calcit calcit.cirru tree show respo.app.updater/updater -p "" -d 1
-calcit calcit.cirru tree show respo.app.updater/updater -p "2,1" -d 1
-
-# Prefer content-based tree operations when available.
-calcit calcit.cirru tree search-replace respo.app.updater/updater \
-  --code 'old-value' --with 'new-value'
-
-calcit calcit.cirru edit add-ns respo.app.feature-x
-calcit calcit.cirru edit add-import respo.app.feature-x \
-  --code 'respo.core :refer $ defcomp div span'
-```
-
-For larger edits, put the Cirru or JSON input in a temporary file and pass it
-with `--file`. Use `--code` for short snippets. The current mutation commands
-do not require a legacy standard-input flag.
-
-After every Snapshot edit, format and inspect the diff:
+Use `calcit edit` and `calcit tree` for Snapshot changes. After editing, run:
 
 ```bash
 calcit calcit.cirru edit format
-git diff -- calcit.cirru
-```
-
-When replacing a definition or moving namespaces, prefer the dedicated
-`edit` commands and use `tree rewrite` for replacements that need references
-to original nodes. For sibling index operations, work from the end toward the
-beginning or re-query paths after each mutation.
-
-## Validation
-
-Install dependencies from `deps.cirru`, then run the canonical checks:
-
-```bash
-caps --ci
-calcit calcit.cirru edit format
-git diff --exit-code -- calcit.cirru
 calcit calcit.cirru --check-only
-calcit calcit.cirru analyze deprecated --summary-only --format json
 calcit calcit.cirru js
+caps --ci
 yarn install --immutable
 yarn vite build --base=./
 ```
 
-`calcit eval` is useful for small semantic or type experiments, but it is not
-a substitute for running the complete project. Keep the snippet top-level
-and remember that `let` bindings use pairs, for example:
+Run only the commands that match the changed area when a full build is not
+needed. Normal execution is a single run; add `-w` or `--watch` only for an
+intentional watch session. Keep workflow Node/Yarn versions aligned with the
+repository configuration.
 
-```bash
-calcit calcit.cirru eval 'let ((x 1)) (+ x 2)'
-```
-
-Warnings from type checking are intentional failures in validation. Inspect
-`.calcit/error.cirru` for the full diagnostic context.
-
-## Runtime and release workflow
-
-The normal JavaScript build is:
-
-```bash
-calcit calcit.cirru js
-yarn vite build --base=./
-```
-
-Use `calcit calcit.cirru -w` or `calcit calcit.cirru js -w` only for an
-explicit watch session. Keep Node and Yarn versions aligned with
-`packageManager` and the repository workflow; CI should activate Corepack
-before Yarn commands.
-
-When changing dependencies, update `deps.cirru`, run `caps --ci`, and verify
-the generated project module view. Do not hand-edit generated module contents.
-
-## Debugging checklist
-
-1. Run `calcit docs agents --full` and `calcit docs read upgrade` if command
-   behavior is unclear.
-2. Use `query def`, `query usages`, and `tree show` before editing.
-3. Re-run `edit format`, `--check-only`, and JavaScript generation after each
-   Snapshot change.
-4. Check `.calcit/error.cirru` when a command reports a shortened error.
-5. Keep stdout free of diagnostics when validating scripts that consume JSON.
-
-The project is maintained with the canonical Calcit Snapshot and the current
-`calcit` command family. Examples in older notes are historical and should not
-be copied into new workflows.
+When dependencies change, update `deps.cirru` with `caps`, use formal release
+versions, and verify the resulting module graph. Never reference deprecated
+`cr`, `compact.cirru`, `lilac`, or `memof` in new project changes.

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   },
   "main": "index.js",
   "scripts": {
-    "compile-page": "cr js",
+    "compile-page": "calcit calcit.cirru js",
     "dev-page": "vite --force",
     "release-page": "vite build --base=./",
-    "watch-page": "cr js -w"
+    "watch-page": "calcit -w calcit.cirru js"
   },
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
   "author": "jiyinyiyong",
   "license": "MIT",
   "dependencies": {
-    "@calcit/procs": "^0.13.27",
+    "@calcit/procs": "^0.13.29",
     "dayjs": "^1.11.19",
     "nanoid": "^5.1.16"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.27":
-  version: 0.13.27
-  resolution: "@calcit/procs@npm:0.13.27"
+"@calcit/procs@npm:^0.13.29":
+  version: 0.13.29
+  resolution: "@calcit/procs@npm:0.13.29"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/f3f2d1a3dd94797f99bec39cbf722b7d98d0308d0643f861997b1accc44fe68f5922149b268881aae1df4a3524968e3f10c58870358952bd959ff4dddcfd326a
+  checksum: 10c0/d8db7c62054dda827557f1bd8c8d7a777c17b40bd43f51fb3b39c57386d1c1a41dad449b641201daa05ad14c38a423601c803b5d9eb3557ae0173ae1a03f570a
   languageName: node
   linkType: hard
 
@@ -1056,7 +1056,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "timegrass@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.27"
+    "@calcit/procs": "npm:^0.13.29"
     bottom-tip: "npm:^0.1.5"
     copy-text-to-clipboard: "npm:^3.2.2"
     dayjs: "npm:^1.11.19"


### PR DESCRIPTION
本地已使用 Calcit 0.13.27 执行 `cr --check-only` 验证通过。

请等待 Actions 全部通过后再合并。此 PR 不应自动合并。